### PR TITLE
Use scores to evalute test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ This is the pelias fuzzy tester library, used for running our
 What are fuzzy tests? See the original [problem statement](https://github.com/pelias/acceptance-tests/issues/109)
 that lead to the creation of this library.
 
+Most importantly, fuzzy tests deliver more than just a single bit of pass or fail for each test:
+they specify a total number of points (a score) for the test, and return how many points out of the
+maximum were achieved. The weighting of individual parts of the test can be adjusted.
+
 **Note:** fuzzy-tester requires NPM version 2 or greater. The NPM team
 [recommends](http://blog.npmjs.org/post/85484771375/how-to-install-npm) you update NPM using NPM
 itself with `sudo npm install -g npm`.
-
 ## Usage
 
 ```
@@ -32,6 +35,8 @@ properties:
  + `priorityThresh` indicates the expected result must be found within the top N locations. This can be set for the entire suite as well as overwritten in individual test cases.
  + `tests` is an array of test cases that make up the suite.
  + `endpoint` the API endpoint (`search`, `reverse`, `suggest`) to target. Defaults to `search`.
+ + `weights` (optional) test suite wide weighting for scores of the individual expectations. See the
+   weights section below
 
 `tests` consists of objects with the following properties:
  + `id` is a unique identifier within the test suite (this could be unnecessary, let's discuss)
@@ -55,6 +60,8 @@ properties:
 
 + `unexpected` is analogous to `expected`, except that you *cannot* specify a `priorityThresh` and the `properties`
   array does *not* support strings.
+ + `weights` (optional) test case specific weighting for scores of the individual expectations. See the
+   weights section below
 
 ## output generators
 The acceptance-tests support multiple different output generators, like an email and terminal output. See `node test
@@ -89,3 +96,22 @@ override the default aliases and define your own in `pelias-config`:
 	}
 }
 ```
+
+## Weights
+
+Weights are used to influence the score each individual expectation contributes to the total score
+for a test. By default, all fields in expected properties, passing the priority threshold, and the
+absence of any unexpected properties each contribute one point.
+
+Any score for any individual property can be changed by specifying an object `weights` in a test
+suite, or in an individual test case. For example, to more heavily weight the `name` property by
+giving it a weight of 10 points, set weights to the following:
+```javascript
+{
+  "properties": {
+    "name": 10
+  }
+}
+```
+
+Weights can be nested and are completely optional, in which case the defaults will be in effect.

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -31,13 +31,14 @@ function findPlaceholders(expected) {
  * properties that are explicitly expected to not be present
  */
 function unexpectedTestsPass(testCase, apiResults) {
-  var unexpected = ( testCase.hasOwnProperty( 'unexpected' ) ) ?
-    testCase.unexpected.properties : [];
+  if (testCase.unexpected === undefined) {
+    return true;
+  }
 
   // test every api result
   return apiResults.every(function(result) {
     // if every unexpected input is not found, the tests pass
-    return unexpected.every(function(property) {
+    return testCase.unexpected.properties.every(function(property) {
       return !equalProperties(property, result.properties);
     });
   });

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -12,12 +12,17 @@ function constructExpectedOutput(properties, locations) {
   return properties.map(function(property) {
     if ( typeof property === 'string' && property in locations ) {
       return locations[property];
+    // this intentionally leaves unmatched location strings as strings
+    // that way it is possible to go back and look for them later
     } else {
       return property;
     }
   });
 }
 
+/**
+ * Find unmatched location strings left from running constructExpectedOutput
+ */
 function findPlaceholders(expected) {
   return expected.filter(function(item) {
     return typeof item === 'string';
@@ -43,6 +48,11 @@ function unexpectedTestsPass(testCase, apiResults) {
   });
 }
 
+/**
+ * Check if a given result is found early enough in api results to satisfy
+ * a priority threshold. Note that the priorityThresh is 1-indexed where
+ * the apiResults are zero-indexed.
+ */
 function inPriorityThresh(apiResults, result, priorityThresh) {
   return apiResults.indexOf(result) <= priorityThresh - 1;
 }

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -2,7 +2,6 @@
 
 var equalProperties = require( '../lib/equal_properties' );
 var isObject = require( 'is-object' );
-var util = require( 'util' );
 
 /**
  * Given the properties of a test case,
@@ -40,6 +39,18 @@ function unexpectedTestsPass(testCase, apiResults) {
     // if every unexpected input is not found, the tests pass
     return testCase.unexpected.properties.every(function(property) {
       return !equalProperties(property, result.properties);
+    });
+  });
+}
+
+function inPriorityThresh(apiResults, result, priorityThresh) {
+  return apiResults.indexOf(result) <= priorityThresh - 1;
+}
+
+function expectedTestsPass(expected, apiResults, priorityThresh) {
+  return expected.every(function(expect) {
+    return apiResults.some(function(result) {
+      return equalProperties(expect, result.properties) && inPriorityThresh(apiResults, result, priorityThresh);
     });
   });
 }
@@ -84,27 +95,6 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     }
   }
 
-  var expectedResultsFound = [];
-
-  for( var ind = 0; ind < apiResults.length; ind++ ){
-    var result = apiResults[ ind ];
-    for( var expectedInd = 0; expectedInd < expected.length; expectedInd++ ){
-      if( expectedResultsFound.indexOf( expectedInd ) === -1 &&
-        equalProperties( expected[ expectedInd ], result.properties ) ){
-        var success = ( ind + 1 ) <= priorityThresh;
-        if( !success ){
-          return {
-            result: 'fail',
-            msg: util.format( 'Result found, but not in top %s. (%s)', priorityThresh, ind+1 )
-          };
-        }
-        else {
-          expectedResultsFound.push( expectedInd );
-        }
-      }
-    }
-  }
-
   if (!unexpectedTestsPass(testCase, apiResults)) {
     return {
       result: 'fail',
@@ -112,15 +102,14 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     };
   }
 
-
-  if ( expectedResultsFound.length === expected.length ) {
-    return { result: 'pass' };
-  }
-
-  return {
+  if (!expectedTestsPass(expected, apiResults, priorityThresh)) {
+    return {
       result: 'fail',
       msg: 'No matching result found.'
     };
+  }
+
+  return { result: 'pass' };
 }
 
 module.exports = evalTest;

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -26,6 +26,24 @@ function findPlaceholders(expected) {
 }
 
 /**
+ * Given a test case and a set of api results,
+ * check every api result to ensure it has none of the
+ * properties that are explicitly expected to not be present
+ */
+function unexpectedTestsPass(testCase, apiResults) {
+  var unexpected = ( testCase.hasOwnProperty( 'unexpected' ) ) ?
+    testCase.unexpected.properties : [];
+
+  // test every api result
+  return apiResults.every(function(result) {
+    // if every unexpected input is not found, the tests pass
+    return unexpected.every(function(property) {
+      return !equalProperties(property, result.properties);
+    });
+  });
+}
+
+/**
  * Given a test-case, the API results for the input it specifies, and a
  * priority-threshold to find the results in, return an object indicating the
  * status of this test (whether it passed, failed, is a placeholder, etc.)
@@ -65,9 +83,6 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     }
   }
 
-  var unexpected = ( testCase.hasOwnProperty( 'unexpected' ) ) ?
-    testCase.unexpected.properties : [];
-
   var expectedResultsFound = [];
 
   for( var ind = 0; ind < apiResults.length; ind++ ){
@@ -87,23 +102,18 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
         }
       }
     }
-
-    for( var unexpectedInd = 0; unexpectedInd < unexpected.length; unexpectedInd++ ){
-      if( equalProperties( unexpected[ unexpectedInd ], result.properties ) ){
-        return {
-          result: 'fail',
-          msg: util.format( 'Unexpected result found.' )
-        };
-      }
-    }
   }
+
+  if (!unexpectedTestsPass(testCase, apiResults)) {
+    return {
+      result: 'fail',
+      msg: 'Unexpected results found'
+    };
+  }
+
 
   if ( expectedResultsFound.length === expected.length ) {
     return { result: 'pass' };
-  }
-
-  if ( expected.length === 0 && unexpected.length > 0 ) {
-    return {result: 'pass'};
   }
 
   return {

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -5,6 +5,27 @@ var isObject = require( 'is-object' );
 var util = require( 'util' );
 
 /**
+ * Given the properties of a test case,
+ * construct the actual expected object.
+ * This simply acounts for pre-defiend locations for now
+ */
+function constructExpectedOutput(properties, locations) {
+  return properties.map(function(property) {
+    if ( typeof property === 'string' && property in locations ) {
+      return locations[property];
+    } else {
+      return property;
+    }
+  });
+}
+
+function findPlaceholders(expected) {
+  return expected.filter(function(item) {
+    return typeof item === 'string';
+  });
+}
+
+/**
  * Given a test-case, the API results for the input it specifies, and a
  * priority-threshold to find the results in, return an object indicating the
  * status of this test (whether it passed, failed, is a placeholder, etc.)
@@ -27,29 +48,20 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     };
   }
 
-  var ind;
   var expected = [];
   if( 'expected' in testCase ){
-    for( ind = 0; ind < testCase.expected.properties.length; ind++ ){
-      var testCaseProps = testCase.expected.properties[ ind ];
-      if( typeof testCaseProps === 'string' ){
-        if( testCaseProps in locations ){
-          expected.push(locations[ testCaseProps ]);
-        }
-        else {
-          return {
-            result: 'placeholder',
-            msg: 'Placeholder test, no `out` object matches in `locations.json`.'
-          };
-        }
-      }
-      else {
-        expected.push( testCaseProps );
-      }
-    }
+    expected = constructExpectedOutput(testCase.expected.properties, locations);
 
     if( 'priorityThresh' in testCase.expected ){
       priorityThresh = testCase.expected.priorityThresh;
+    }
+
+    var missed_locations = findPlaceholders(expected);
+    if (missed_locations.length > 0) {
+      return {
+        result: 'placeholder',
+        msg: 'Placeholder: no matches for ' + missed_locations.join(', ') + ' in `locations.json`.'
+      };
     }
   }
 
@@ -58,7 +70,7 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
 
   var expectedResultsFound = [];
 
-  for( ind = 0; ind < apiResults.length; ind++ ){
+  for( var ind = 0; ind < apiResults.length; ind++ ){
     var result = apiResults[ ind ];
     for( var expectedInd = 0; expectedInd < expected.length; expectedInd++ ){
       if( expectedResultsFound.indexOf( expectedInd ) === -1 &&

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -5,8 +5,13 @@ var sanitiseTestCase = require( '../lib/sanitiseTestCase' );
 var isObject = require( 'is-object' );
 
 function formatTestErrors(score) {
-  return 'score ' + score.score + ' out of ' + score.max_score +
-    '\ndiff: ' + JSON.stringify(score.diff, null, 2);
+  var message = 'score ' + score.score + ' out of ' + score.max_score;
+
+  if (score.score < score.max_score) {
+    message += '\ndiff: ' + JSON.stringify(score.diff, null, 2);
+  }
+
+  return message;
 }
 
 /**
@@ -40,16 +45,9 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
 
   var score = scoreTest(testCase, apiResults, priorityThresh);
 
-  if (score.score < score.max_score) {
-    return {
-      result: 'fail',
-      msg: formatTestErrors(score)
-    };
-  }
-
   return {
-    result: 'pass',
-    msg: 'score ' + score.score + '/' + score.max_score
+    result: (score.score < score.max_score) ? 'fail' : 'pass',
+    msg: formatTestErrors(score)
   };
 }
 

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -15,14 +15,30 @@ function formatTestErrors(score) {
 }
 
 /**
+ * Combine a context passed in from a test suite with properties
+ * from one individual test case to create the final context for this
+ * test case. It handles locations, weights, and priorityThresh
+ */
+function makeTestContext( testCase, context ) {
+  context.locations = context.locations || {};
+  context.weights = context.weights || {};
+
+  if( 'expected' in testCase && 'priorityThresh' in testCase.expected ){
+    context.priorityThresh = testCase.expected.priorityThresh;
+  }
+
+  return context;
+}
+
+/**
  * Given a test-case, the API results for the input it specifies, and a
  * priority-threshold to find the results in, return an object indicating the
  * status of this test (whether it passed, failed, is a placeholder, etc.)
  */
-function evalTest( priorityThresh, testCase, apiResults, locations ){
-  locations = locations || {};
+function evalTest( testCase, apiResults, context ){
+  context = makeTestContext( testCase, context );
 
-  testCase = sanitiseTestCase(testCase, locations);
+  testCase = sanitiseTestCase(testCase, context.locations);
 
   // on error, sanitiseTestCase returns an error message string
   if (typeof testCase === 'string') {
@@ -39,14 +55,12 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     };
   }
 
-  if( 'expected' in testCase && 'priorityThresh' in testCase.expected ){
-    priorityThresh = testCase.expected.priorityThresh;
-  }
-
-  var score = scoreTest(testCase, apiResults, priorityThresh);
+  var score = scoreTest(testCase, apiResults, context);
 
   return {
     result: (score.score < score.max_score) ? 'fail' : 'pass',
+    score: score.score,
+    max_score: score.max_score,
     msg: formatTestErrors(score)
   };
 }

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var equalProperties = require( '../lib/equal_properties' );
+var scoreTest = require( '../lib/scoreTest' );
 var isObject = require( 'is-object' );
 
 /**
@@ -9,6 +9,11 @@ var isObject = require( 'is-object' );
  * This simply acounts for pre-defiend locations for now
  */
 function constructExpectedOutput(properties, locations) {
+  // some tests don't have a properties array, but this is easy to fix
+  if (typeof properties === 'string') {
+    properties = [properties];
+  }
+
   return properties.map(function(property) {
     if ( typeof property === 'string' && property in locations ) {
       return locations[property];
@@ -29,40 +34,9 @@ function findPlaceholders(expected) {
   });
 }
 
-/**
- * Given a test case and a set of api results,
- * check every api result to ensure it has none of the
- * properties that are explicitly expected to not be present
- */
-function unexpectedTestsPass(testCase, apiResults) {
-  if (testCase.unexpected === undefined) {
-    return true;
-  }
-
-  // test every api result
-  return apiResults.every(function(result) {
-    // if every unexpected input is not found, the tests pass
-    return testCase.unexpected.properties.every(function(property) {
-      return !equalProperties(property, result.properties);
-    });
-  });
-}
-
-/**
- * Check if a given result is found early enough in api results to satisfy
- * a priority threshold. Note that the priorityThresh is 1-indexed where
- * the apiResults are zero-indexed.
- */
-function inPriorityThresh(apiResults, result, priorityThresh) {
-  return apiResults.indexOf(result) <= priorityThresh - 1;
-}
-
-function expectedTestsPass(expected, apiResults, priorityThresh) {
-  return expected.every(function(expect) {
-    return apiResults.some(function(result) {
-      return equalProperties(expect, result.properties) && inPriorityThresh(apiResults, result, priorityThresh);
-    });
-  });
+function formatTestErrors(score) {
+  return 'score ' + score.score + ' out of ' + score.max_score +
+    '\ndiff: ' + JSON.stringify(score.diff, null, 2);
 }
 
 /**
@@ -88,15 +62,14 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     };
   }
 
-  var expected = [];
   if( 'expected' in testCase ){
-    expected = constructExpectedOutput(testCase.expected.properties, locations);
+    testCase.expected.properties = constructExpectedOutput(testCase.expected.properties, locations);
 
     if( 'priorityThresh' in testCase.expected ){
       priorityThresh = testCase.expected.priorityThresh;
     }
 
-    var missed_locations = findPlaceholders(expected);
+    var missed_locations = findPlaceholders(testCase.expected.properties);
     if (missed_locations.length > 0) {
       return {
         result: 'placeholder',
@@ -105,17 +78,12 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     }
   }
 
-  if (!unexpectedTestsPass(testCase, apiResults)) {
-    return {
-      result: 'fail',
-      msg: 'Unexpected results found'
-    };
-  }
+  var score = scoreTest(testCase, apiResults, priorityThresh);
 
-  if (!expectedTestsPass(expected, apiResults, priorityThresh)) {
+  if (score.score < score.max_score) {
     return {
       result: 'fail',
-      msg: 'No matching result found.'
+      msg: formatTestErrors(score)
     };
   }
 

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -1,38 +1,8 @@
 'use strict';
 
 var scoreTest = require( '../lib/scoreTest' );
+var sanitiseTestCase = require( '../lib/sanitiseTestCase' );
 var isObject = require( 'is-object' );
-
-/**
- * Given the properties of a test case,
- * construct the actual expected object.
- * This simply acounts for pre-defiend locations for now
- */
-function constructExpectedOutput(properties, locations) {
-  // some tests don't have a properties array, but this is easy to fix
-  if (typeof properties === 'string') {
-    properties = [properties];
-  }
-
-  return properties.map(function(property) {
-    if ( typeof property === 'string' && property in locations ) {
-      return locations[property];
-    // this intentionally leaves unmatched location strings as strings
-    // that way it is possible to go back and look for them later
-    } else {
-      return property;
-    }
-  });
-}
-
-/**
- * Find unmatched location strings left from running constructExpectedOutput
- */
-function findPlaceholders(expected) {
-  return expected.filter(function(item) {
-    return typeof item === 'string';
-  });
-}
 
 function formatTestErrors(score) {
   return 'score ' + score.score + ' out of ' + score.max_score +
@@ -47,11 +17,13 @@ function formatTestErrors(score) {
 function evalTest( priorityThresh, testCase, apiResults, locations ){
   locations = locations || {};
 
-  if( (!( 'expected' in testCase ) || testCase.expected.properties === null) &&
-      !( 'unexpected' in testCase ) ){
+  testCase = sanitiseTestCase(testCase, locations);
+
+  // on error, sanitiseTestCase returns an error message string
+  if (typeof testCase === 'string') {
     return {
       result: 'placeholder',
-      msg: 'Placeholder test, no `expected` specified.'
+      msg: testCase
     };
   }
 
@@ -62,20 +34,8 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     };
   }
 
-  if( 'expected' in testCase ){
-    testCase.expected.properties = constructExpectedOutput(testCase.expected.properties, locations);
-
-    if( 'priorityThresh' in testCase.expected ){
-      priorityThresh = testCase.expected.priorityThresh;
-    }
-
-    var missed_locations = findPlaceholders(testCase.expected.properties);
-    if (missed_locations.length > 0) {
-      return {
-        result: 'placeholder',
-        msg: 'Placeholder: no matches for ' + missed_locations.join(', ') + ' in `locations.json`.'
-      };
-    }
+  if( 'expected' in testCase && 'priorityThresh' in testCase.expected ){
+    priorityThresh = testCase.expected.priorityThresh;
   }
 
   var score = scoreTest(testCase, apiResults, priorityThresh);

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -3,21 +3,15 @@
 var equalProperties = require( '../lib/equal_properties' );
 var isObject = require( 'is-object' );
 var util = require( 'util' );
-var path = require( 'path' );
-
-var locations;
-try {
-    locations = require( path.resolve(process.cwd() + '/locations.json') );
-} catch (e) {
-    locations = [];
-}
 
 /**
  * Given a test-case, the API results for the input it specifies, and a
  * priority-threshold to find the results in, return an object indicating the
  * status of this test (whether it passed, failed, is a placeholder, etc.)
  */
-function evalTest( priorityThresh, testCase, apiResults ){
+function evalTest( priorityThresh, testCase, apiResults, locations ){
+  locations = locations || {};
+
   if( (!( 'expected' in testCase ) || testCase.expected.properties === null) &&
       !( 'unexpected' in testCase ) ){
     return {

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -15,13 +15,26 @@ function formatTestErrors(score) {
 }
 
 /**
+ * Ensure the weights object is valid by filling in any missing
+ * default values.
+ */
+function setDefaultWeights(weights) {
+  weights = weights || {};
+  weights.properties = weights.properties || {};
+  weights.priorityThresh = weights.priorityThresh || 1;
+  weights.unexpected = weights.unexpected || 1;
+
+  return weights;
+}
+
+/**
  * Combine a context passed in from a test suite with properties
  * from one individual test case to create the final context for this
  * test case. It handles locations, weights, and priorityThresh
  */
 function makeTestContext( testCase, context ) {
   context.locations = context.locations || {};
-  context.weights = context.weights || {};
+  context.weights = setDefaultWeights(context.weights);
 
   if( 'expected' in testCase && 'priorityThresh' in testCase.expected ){
     context.priorityThresh = testCase.expected.priorityThresh;

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -87,7 +87,10 @@ function evalTest( priorityThresh, testCase, apiResults, locations ){
     };
   }
 
-  return { result: 'pass' };
+  return {
+    result: 'pass',
+    msg: 'score ' + score.score + '/' + score.max_score
+  };
 }
 
 module.exports = evalTest;

--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -144,8 +144,14 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
         var results;
 
         if( res.statusCode === 200 ){
+          var context = {
+            priorityThresh: testSuite.priorityThresh,
+            locations: locations,
+            weights: testSuite.weights
+          };
+
           test_interval.decreaseBackoff();
-          results = evalTest( testSuite.priorityThresh, testCase, res.body.features, locations );
+          results = evalTest( testCase, res.body.features, context );
         } else { // unexpected (non 200 or retry) status code
           test_interval.increaseBackoff();
           printRequestErrorMessage(testCase, res);

--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -7,9 +7,17 @@
 var evalTest = require( '../lib/eval_test' );
 var ExponentialBackoff = require( '../lib/ExponentialBackoff');
 var request = require( 'request' );
+var path = require( 'path' );
 var util = require( 'util' );
 
 var validTestStatuses = [ 'pass', 'fail', undefined ];
+
+var locations;
+try {
+    locations = require( path.resolve(process.cwd() + '/locations.json') );
+} catch (e) {
+    locations = {};
+}
 
 function validateTestSuite(testSuite) {
   testSuite.tests.forEach( function ( testCase ){
@@ -137,7 +145,7 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
 
         if( res.statusCode === 200 ){
           test_interval.decreaseBackoff();
-          results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
+          results = evalTest( testSuite.priorityThresh, testCase, res.body.features, locations );
         } else { // unexpected (non 200 or retry) status code
           test_interval.increaseBackoff();
           printRequestErrorMessage(testCase, res);

--- a/lib/sanitiseTestCase.js
+++ b/lib/sanitiseTestCase.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Given the properties of a test case,
+ * construct the actual expected object.
+ * This simply acounts for pre-defiend locations
+ */
+function constructExpectedOutput(properties, locations) {
+  return properties.map(function(property) {
+    if ( typeof property === 'string' && property in locations ) {
+      return locations[property];
+    // this intentionally leaves unmatched location strings as strings
+    // that way it is possible to go back and look for them later
+    } else {
+      return property;
+    }
+  });
+}
+
+/**
+ * Find unmatched location strings left from running constructExpectedOutput
+ */
+function findPlaceholders(expected) {
+  return expected.filter(function(item) {
+    return typeof item === 'string';
+  });
+}
+
+function normalizeProperties(properties) {
+  // some tests don't have a properties array, but this is easy to fix
+  if (typeof properties === 'string') {
+    properties = [properties];
+  }
+  return properties;
+}
+
+function sanitiseTestCase(testCase, locations)
+{
+  locations = locations || {};
+
+  if (!testCase.expected && !testCase.unexpected) {
+    return 'Placeholder test: no `expected` or `unexpected` given';
+  }
+
+  if (testCase.expected) {
+    if (!testCase.expected.properties) {
+      return 'Placeholder test: `expected` block is empty';
+    }
+
+    testCase.expected.properties = normalizeProperties(testCase.expected.properties);
+    testCase.expected.properties = constructExpectedOutput(testCase.expected.properties, locations);
+
+    var unmatched_placeholders = findPlaceholders(testCase.expected.properties);
+    if (unmatched_placeholders.length > 0) {
+      return 'Placeholder: no matches for ' + unmatched_placeholders.join(', ') + ' in `locations.json`.';
+    }
+  }
+
+  return testCase;
+}
+
+module.exports = sanitiseTestCase;

--- a/lib/sanitiseTestCase.js
+++ b/lib/sanitiseTestCase.js
@@ -26,8 +26,12 @@ function findPlaceholders(expected) {
   });
 }
 
+/**
+ * some tests don't have a properties array, if the properties
+ * object is just a single string, turn it into a one element
+ * array
+ */
 function normalizeProperties(properties) {
-  // some tests don't have a properties array, but this is easy to fix
   if (typeof properties === 'string') {
     properties = [properties];
   }

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -22,6 +22,14 @@ function createDiff(expectation, result) {
   });
 }
 
+function filterDiffs(diff) {
+  if( diff === '' || (Array.isArray(diff) && diff.length === 0)) {
+    return false;
+  }
+  return true;
+}
+
+
 /**
  * function to be used with Array.reduce to combine several subscores for
  * the same object and build one score that combines all of them.
@@ -32,6 +40,7 @@ function combineScores(total_score, this_score) {
   var new_diff = total_score.diff;
   if (this_score.diff) {
     new_diff = total_score.diff.concat(this_score.diff);
+    new_diff = new_diff.filter(filterDiffs);
   }
 
   return {

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -22,6 +22,12 @@ function createDiff(expectation, result) {
   });
 }
 
+/**
+ * function to be used with Array.reduce to combine several subscores for
+ * the same object and build one score that combines all of them.
+ * It totals up the actual and maximum score, and concatenates
+ * multiple diff or error outputs into an array
+ */
 function combineScores(total_score, this_score) {
   var new_diff = total_score.diff;
   if (this_score.diff) {
@@ -35,6 +41,13 @@ function combineScores(total_score, this_score) {
   };
 }
 
+/**
+ * Small helper function to determine if a given apiResult is high
+ * enough in a set of results to pass a priority threshold.
+ * Caveat: the result object must be the exact same javascript object
+ * as the one taken from the apiResults, not just another object with
+ * identical properties
+ */
 function inPriorityThresh(apiResults, result, priorityThresh) {
   var index = apiResults.indexOf(result);
   return index !== -1 && index <= priorityThresh - 1;

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -22,7 +22,7 @@ function createDiff(expectation, result) {
   });
 }
 
-function reduceScores(total_score, this_score) {
+function combineScores(total_score, this_score) {
   var new_diff = total_score.diff;
   if (this_score.diff) {
     new_diff = total_score.diff.concat(this_score.diff);
@@ -43,6 +43,6 @@ function inPriorityThresh(apiResults, result, priorityThresh) {
 module.exports = {
   initial_score: initial_score,
   createDiff: createDiff,
-  reduceScores: reduceScores,
+  combineScores: combineScores,
   inPriorityThresh: inPriorityThresh
 };

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -1,0 +1,48 @@
+var deepDiff = require( 'deep-diff' );
+
+var initial_score = {score: 0, max_score: 0, diff: []};
+
+/**
+ * Use the deep-diff library to create an (almost too) detailed description
+ * of the differences between the expected and actual properties. Some massaging
+ * of the data so only the parts we care about are shown is done.
+ */
+function createDiff(expectation, result) {
+  var diff = deepDiff.diff(expectation, result);
+
+  // objects with no differences have an undefined diff
+  if (diff === undefined) {
+    return ''; // return an empty string for less confusing output later
+  }
+
+  // filter out diff elements corresponding to a new element on the right side
+  // these are ignored by our tests and would just be noise
+  return diff.filter(function(diff_part) {
+    return diff_part.kind !== 'N';
+  });
+}
+
+function reduceScores(total_score, this_score) {
+  var new_diff = total_score.diff;
+  if (this_score.diff) {
+    new_diff = total_score.diff.concat(this_score.diff);
+  }
+
+  return {
+    score: total_score.score + this_score.score,
+    max_score: total_score.max_score + this_score.max_score,
+    diff: new_diff
+  };
+}
+
+function inPriorityThresh(apiResults, result, priorityThresh) {
+  var index = apiResults.indexOf(result);
+  return index !== -1 && index <= priorityThresh - 1;
+}
+
+module.exports = {
+  initial_score: initial_score,
+  createDiff: createDiff,
+  reduceScores: reduceScores,
+  inPriorityThresh: inPriorityThresh
+};

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -20,7 +20,7 @@ function scorePrimitiveProperty(expectation, result, weight) {
  * through all the keys, calculating the subscores, and aggregating them
  */
 function scoreProperties(expectation, result, weight) {
-  if (isObject(expectation)) {
+  if (isObject(expectation) && isObject(result)) {
     weight = weight || {};
     var subscores = Object.keys(expectation).map(function(property){
       return scoreProperties(expectation[property], result[property], weight[property]);

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -1,11 +1,33 @@
 'use strict';
 
 var isObject = require( 'is-object' );
+var deepDiff = require( 'deep-diff' );
+
+/**
+ * Use the deep-diff library to create an (almost too) detailed description
+ * of the differences between the expected and actual properties. Some massaging
+ * of the data so only the parts we care about are shown is done.
+ */
+function createDiff(expectation, result) {
+  var diff = deepDiff.diff(expectation, result);
+
+  // objects with no differences have an undefined diff
+  if (diff === undefined) {
+    return ''; // return an empty string for less confusing output later
+  }
+
+  // filter out diff elements corresponding to a new element on the right side
+  // these are ignored by our tests and would just be noise
+  return diff.filter(function(diff_part) {
+    return diff_part.kind !== 'N';
+  });
+}
 
 function reduceScores(total_score, this_score) {
   return {
     score: total_score.score + this_score.score,
-    max_score: total_score.max_score + this_score.max_score
+    max_score: total_score.max_score + this_score.max_score,
+    diff: total_score.diff // simply pass along the diff, it's recalculated at the object level
   };
 }
 
@@ -25,7 +47,7 @@ module.exports = function scoreProperties(expectation, result, weight) {
       return scoreProperties(expectation[property], result[property], weight[property]);
     });
 
-    return subscores.reduce(reduceScores, { score: 0, max_score: 0});
+    return subscores.reduce(reduceScores, { score: 0, max_score: 0, diff: createDiff(expectation, result)});
   } else {
     return scorePrimitiveProperty(expectation, result, weight);
   }

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -20,7 +20,7 @@ function scoreProperties(expectation, result, weight) {
     });
 
     var diff = [helpers.createDiff(expectation, result)];
-    return subscores.reduce(helpers.reduceScores, { score: 0, max_score: 0, diff: diff});
+    return subscores.reduce(helpers.combineScores, { score: 0, max_score: 0, diff: diff});
   } else {
     return scorePrimitiveProperty(expectation, result, weight);
   }

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -9,21 +9,24 @@ function reduceScores(total_score, this_score) {
   };
 }
 
-function scorePrimitiveProperty(expectation, result) {
+function scorePrimitiveProperty(expectation, result, weight) {
+  weight = weight || 1;
+
   return {
-    score: expectation === result ? 1: 0,
-    max_score: 1
+    score: expectation === result ? weight : 0,
+    max_score: weight
   };
 }
 
-module.exports = function scoreProperties(expectation, result) {
+module.exports = function scoreProperties(expectation, result, weight) {
   if (isObject(expectation)) {
+    weight = weight || {};
     var subscores = Object.keys(expectation).map(function(property){
-      return scoreProperties(expectation[property], result[property]);
+      return scoreProperties(expectation[property], result[property], weight[property]);
     });
 
     return subscores.reduce(reduceScores, { score: 0, max_score: 0});
   } else {
-    return scorePrimitiveProperty(expectation, result);
+    return scorePrimitiveProperty(expectation, result, weight);
   }
 };

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -3,6 +3,9 @@
 var isObject = require( 'is-object' );
 var helpers = require( '../lib/scoreHelpers' );
 
+/**
+ * Helper function to score javascript primitives (i.e. not objects)
+ */
 function scorePrimitiveProperty(expectation, result, weight) {
   weight = weight || 1;
 
@@ -12,6 +15,10 @@ function scorePrimitiveProperty(expectation, result, weight) {
   };
 }
 
+/**
+ * Calculate the score of an api result against given expectations by iterating
+ * through all the keys, calculating the subscores, and aggregating them
+ */
 function scoreProperties(expectation, result, weight) {
   if (isObject(expectation)) {
     weight = weight || {};

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -9,6 +9,13 @@ function reduceScores(total_score, this_score) {
   };
 }
 
+function scorePrimitiveProperty(expectation, result) {
+  return {
+    score: expectation === result ? 1: 0,
+    max_score: 1
+  };
+}
+
 module.exports = function scoreProperties(expectation, result) {
   if (isObject(expectation)) {
     var subscores = Object.keys(expectation).map(function(property){
@@ -17,9 +24,6 @@ module.exports = function scoreProperties(expectation, result) {
 
     return subscores.reduce(reduceScores, { score: 0, max_score: 0});
   } else {
-    return {
-      score: expectation === result ? 1: 0,
-      max_score: 1
-    };
+    return scorePrimitiveProperty(expectation, result);
   }
 };

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var isObject = require( 'is-object' );
+
+function reduceScores(total_score, this_score) {
+  return {
+    score: total_score.score + this_score.score,
+    max_score: total_score.max_score + this_score.max_score
+  };
+}
+
+module.exports = function scoreProperties(expectation, result) {
+  if (isObject(expectation)) {
+    var subscores = Object.keys(expectation).map(function(property){
+      return scoreProperties(expectation[property], result[property]);
+    });
+
+    return subscores.reduce(reduceScores, { score: 0, max_score: 0});
+  } else {
+    return {
+      score: expectation === result ? 1: 0,
+      max_score: 1
+    };
+  }
+};

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -1,35 +1,7 @@
 'use strict';
 
 var isObject = require( 'is-object' );
-var deepDiff = require( 'deep-diff' );
-
-/**
- * Use the deep-diff library to create an (almost too) detailed description
- * of the differences between the expected and actual properties. Some massaging
- * of the data so only the parts we care about are shown is done.
- */
-function createDiff(expectation, result) {
-  var diff = deepDiff.diff(expectation, result);
-
-  // objects with no differences have an undefined diff
-  if (diff === undefined) {
-    return ''; // return an empty string for less confusing output later
-  }
-
-  // filter out diff elements corresponding to a new element on the right side
-  // these are ignored by our tests and would just be noise
-  return diff.filter(function(diff_part) {
-    return diff_part.kind !== 'N';
-  });
-}
-
-function reduceScores(total_score, this_score) {
-  return {
-    score: total_score.score + this_score.score,
-    max_score: total_score.max_score + this_score.max_score,
-    diff: total_score.diff // simply pass along the diff, it's recalculated at the object level
-  };
-}
+var helpers = require( '../lib/scoreHelpers' );
 
 function scorePrimitiveProperty(expectation, result, weight) {
   weight = weight || 1;
@@ -40,15 +12,18 @@ function scorePrimitiveProperty(expectation, result, weight) {
   };
 }
 
-module.exports = function scoreProperties(expectation, result, weight) {
+function scoreProperties(expectation, result, weight) {
   if (isObject(expectation)) {
     weight = weight || {};
     var subscores = Object.keys(expectation).map(function(property){
       return scoreProperties(expectation[property], result[property], weight[property]);
     });
 
-    return subscores.reduce(reduceScores, { score: 0, max_score: 0, diff: createDiff(expectation, result)});
+    var diff = [helpers.createDiff(expectation, result)];
+    return subscores.reduce(helpers.reduceScores, { score: 0, max_score: 0, diff: diff});
   } else {
     return scorePrimitiveProperty(expectation, result, weight);
   }
-};
+}
+
+module.exports = scoreProperties;

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -55,8 +55,10 @@ function scoreUnexpected(unexpected, apiResults, weight) {
  */
 function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight) { // jshint ignore:line
   weight = weight || {};
-  var subscores = [scoreProperties(expected, apiResult.properties, weight.properties),
-    scorePriorityThresh(priorityThresh, apiResult, apiResults, weight.priorityThresh)];
+  var subscores = [
+    scoreProperties(expected, apiResult.properties, weight.properties),
+    scorePriorityThresh(priorityThresh, apiResult, apiResults, weight.priorityThresh)
+  ];
 
   return subscores.reduce(helpers.combineScores, helpers.initial_score);
 }

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -8,8 +8,6 @@ var scoreProperties = require( '../lib/scoreProperties' );
  * Otherwise, full points.
  */
 function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
-  weight = weight || 1;
-
   var index = apiResults.indexOf(result);
   var diff = '';
   var score = weight;
@@ -32,8 +30,6 @@ function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
  * are completely absent from all API results. Otherwise no points.
  */
 function scoreUnexpected(unexpected, apiResults, weight) {
-  weight = weight || 1;
-
   // unexpected result should be absent from every returned result
   var pass = apiResults.every(function(result) {
     // if every unexpected input is not found, the tests pass
@@ -54,7 +50,6 @@ function scoreUnexpected(unexpected, apiResults, weight) {
  * for its properties and whether or not it satisfies the priorityThresh
  */
 function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight) { // jshint ignore:line
-  weight = weight || {};
   var subscores = [
     scoreProperties(expected, apiResult.properties, weight.properties),
     scorePriorityThresh(priorityThresh, apiResult, apiResults, weight.priorityThresh)

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -48,7 +48,7 @@ function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight)
   var subscores = [scoreProperties(expected, apiResult.properties, weight.properties),
     scorePriorityThresh(priorityThresh, apiResult, apiResults, weight.priorityThresh)];
 
-  return subscores.reduce(helpers.reduceScores, helpers.initial_score);
+  return subscores.reduce(helpers.combineScores, helpers.initial_score);
 }
 
 function sortScores(score_a, score_b) {
@@ -81,7 +81,7 @@ function scoreTest(testCase, apiResults, priorityThresh, weights) {
     scores = scores.concat(scoreUnexpected(testCase.unexpected, apiResults, weights.unexpected));
   }
 
-  return scores.reduce(helpers.reduceScores, helpers.initial_score);
+  return scores.reduce(helpers.combineScores, helpers.initial_score);
 }
 
 module.exports = scoreTest;

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -49,10 +49,10 @@ function scoreUnexpected(unexpected, apiResults, weight) {
  * Score one result from the set of api results by combining the score
  * for its properties and whether or not it satisfies the priorityThresh
  */
-function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight) { // jshint ignore:line
+function scoreOneResult(expected, apiResult, apiResults, context) {
   var subscores = [
-    scoreProperties(expected, apiResult.properties, weight.properties),
-    scorePriorityThresh(priorityThresh, apiResult, apiResults, weight.priorityThresh)
+    scoreProperties(expected, apiResult.properties, context.weights.properties),
+    scorePriorityThresh(context.priorityThresh, apiResult, apiResults, context.weights.priorityThresh)
   ];
 
   return subscores.reduce(helpers.combineScores, helpers.initial_score);
@@ -69,9 +69,9 @@ function sortScores(score_a, score_b) {
  * Score one (out of potentially many) expectations in a test suite by finding
  * the highest score of any api result when scored against this expectation.
  */
-function scoreOneExpectation(expected, apiResults, priorityThresh, weights) {
+function scoreOneExpectation(expected, apiResults, context) {
   return apiResults.map(function(result) {
-    var score = scoreOneResult(expected, result, apiResults, priorityThresh, weights);
+    var score = scoreOneResult(expected, result, apiResults, context);
     return score;
   }).sort(sortScores)[0];
 }
@@ -85,7 +85,7 @@ function scoreTest(testCase, apiResults, context) {
 
   if (testCase.expected) {
     scores = scores.concat(testCase.expected.properties.map(function(expected) {
-        return scoreOneExpectation(expected, apiResults, context.priorityThresh, context.weights);
+        return scoreOneExpectation(expected, apiResults, context);
     }));
   }
 

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -32,10 +32,6 @@ function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
  * are completely absent from all API results. Otherwise no points.
  */
 function scoreUnexpected(unexpected, apiResults, weight) {
-  if (unexpected === undefined) {
-    return helpers.initial_score;
-  }
-
   weight = weight || 1;
 
   // unexpected result should be absent from every returned result
@@ -89,10 +85,6 @@ function scoreOneExpectation(expected, apiResults, priorityThresh, weights) {
  */
 function scoreTest(testCase, apiResults, priorityThresh, weights) {
   weights = weights || {};
-
-  if(testCase === undefined) {
-    return helpers.initial_score;
-  }
 
   var scores = [];
 

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -36,8 +36,6 @@ function scoreUnexpected(unexpected, apiResults, weight) {
     });
   });
 
-
-
   return {
     score: pass ? weight : 0,
     max_score: weight,

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -85,19 +85,17 @@ function scoreOneExpectation(expected, apiResults, priorityThresh, weights) {
  * Score an entire test by combining the score for each expectation, and the
  * score for any unexpected properties.
  */
-function scoreTest(testCase, apiResults, priorityThresh, weights) {
-  weights = weights || {};
-
+function scoreTest(testCase, apiResults, context) {
   var scores = [];
 
   if (testCase.expected) {
     scores = scores.concat(testCase.expected.properties.map(function(expected) {
-        return scoreOneExpectation(expected, apiResults, priorityThresh, weights);
+        return scoreOneExpectation(expected, apiResults, context.priorityThresh, context.weights);
     }));
   }
 
   if (testCase.unexpected) {
-    scores = scores.concat(scoreUnexpected(testCase.unexpected, apiResults, weights.unexpected));
+    scores = scores.concat(scoreUnexpected(testCase.unexpected, apiResults, context.weights.unexpected));
   }
 
   return scores.reduce(helpers.combineScores, helpers.initial_score);

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -1,0 +1,89 @@
+var helpers = require( '../lib/scoreHelpers' );
+var equalProperties = require( '../lib/equal_properties' );
+var scoreProperties = require( '../lib/scoreProperties' );
+
+function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
+  weight = weight || 1;
+
+  var index = apiResults.indexOf(result);
+  var diff = '';
+  var score = weight;
+  var success = helpers.inPriorityThresh(apiResults, result, priorityThresh);
+  if (!success) {
+    score = 0;
+    diff = 'priorityThresh is ' + priorityThresh + ' but found at position ' + (index + 1);
+  }
+
+  return {
+    score: score,
+    max_score: weight,
+    diff: diff
+  };
+}
+
+function scoreUnexpected(unexpected, apiResults, weight) {
+  if (unexpected === undefined || apiResults === undefined) {
+    return helpers.initial_score;
+  }
+
+  weight = weight || 1;
+
+  // unexpected result should be absent from every returned result
+  var pass = apiResults.every(function(result) {
+    // if every unexpected input is not found, the tests pass
+    return unexpected.properties.every(function(property) {
+      return !equalProperties(property, result.properties);
+    });
+  });
+
+
+
+  return {
+    score: pass ? weight : 0,
+    max_score: weight,
+    diff: pass ? '' : 'unexpected result found'
+  };
+}
+
+function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight) { // jshint ignore:line
+  weight = weight || {};
+  var subscores = [scoreProperties(expected, apiResult.properties, weight.properties),
+    scorePriorityThresh(priorityThresh, apiResult, apiResults, weight.priorityThresh)];
+
+  return subscores.reduce(helpers.reduceScores, helpers.initial_score);
+}
+
+function sortScores(score_a, score_b) {
+  return score_b.score - score_a.score;
+}
+
+function scoreOneExpectation(expected, apiResults, priorityThresh, weights) {
+  return apiResults.map(function(result) {
+    var score = scoreOneResult(expected, result, apiResults, priorityThresh, weights);
+    return score;
+  }).sort(sortScores)[0];
+}
+
+function scoreTest(testCase, apiResults, priorityThresh, weights) {
+  weights = weights || {};
+
+  if(testCase === undefined) {
+    return helpers.initial_score;
+  }
+
+  var scores = [];
+
+  if (testCase.expected) {
+    scores = scores.concat(testCase.expected.properties.map(function(expected) {
+        return scoreOneExpectation(expected, apiResults, priorityThresh, weights);
+    }));
+  }
+
+  if (testCase.unexpected) {
+    scores = scores.concat(scoreUnexpected(testCase.unexpected, apiResults, weights.unexpected));
+  }
+
+  return scores.reduce(helpers.reduceScores, helpers.initial_score);
+}
+
+module.exports = scoreTest;

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -22,7 +22,7 @@ function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
 }
 
 function scoreUnexpected(unexpected, apiResults, weight) {
-  if (unexpected === undefined || apiResults === undefined) {
+  if (unexpected === undefined) {
     return helpers.initial_score;
   }
 

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -2,6 +2,11 @@ var helpers = require( '../lib/scoreHelpers' );
 var equalProperties = require( '../lib/equal_properties' );
 var scoreProperties = require( '../lib/scoreProperties' );
 
+/**
+ * Calculate the score component for a results object's position in the returned
+ * results. If it is later in the results than the threshold, no points.
+ * Otherwise, full points.
+ */
 function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
   weight = weight || 1;
 
@@ -21,6 +26,11 @@ function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
   };
 }
 
+/**
+ * Calculate the score component for the absence of unexpected properties in
+ * API results. Full points are awarded if all of the unexpected properties
+ * are completely absent from all API results. Otherwise no points.
+ */
 function scoreUnexpected(unexpected, apiResults, weight) {
   if (unexpected === undefined) {
     return helpers.initial_score;
@@ -43,6 +53,10 @@ function scoreUnexpected(unexpected, apiResults, weight) {
   };
 }
 
+/**
+ * Score one result from the set of api results by combining the score
+ * for its properties and whether or not it satisfies the priorityThresh
+ */
 function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight) { // jshint ignore:line
   weight = weight || {};
   var subscores = [scoreProperties(expected, apiResult.properties, weight.properties),
@@ -51,10 +65,17 @@ function scoreOneResult(expected, apiResult, apiResults, priorityThresh, weight)
   return subscores.reduce(helpers.combineScores, helpers.initial_score);
 }
 
+/**
+ * Helper method to sort scores in descending order
+ */
 function sortScores(score_a, score_b) {
   return score_b.score - score_a.score;
 }
 
+/**
+ * Score one (out of potentially many) expectations in a test suite by finding
+ * the highest score of any api result when scored against this expectation.
+ */
 function scoreOneExpectation(expected, apiResults, priorityThresh, weights) {
   return apiResults.map(function(result) {
     var score = scoreOneResult(expected, result, apiResults, priorityThresh, weights);
@@ -62,6 +83,10 @@ function scoreOneExpectation(expected, apiResults, priorityThresh, weights) {
   }).sort(sortScores)[0];
 }
 
+/**
+ * Score an entire test by combining the score for each expectation, and the
+ * score for any unexpected properties.
+ */
 function scoreTest(testCase, apiResults, priorityThresh, weights) {
   weights = weights || {};
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "colors": "^1.x.x",
     "commander": "2.7.0",
+    "deep-diff": "0.3.2",
     "fs-extra": "^0.22.1",
     "handlebars": "^3.x.x",
     "is-object": "^1.0.1",

--- a/test/eval_test.js
+++ b/test/eval_test.js
@@ -51,6 +51,24 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
       expected: 'placeholder'
     },
     {
+      description: 'Test case with string in properties array matching location uses that location',
+      priorityThresh: 2,
+      locations:  {
+          'my home': {
+              'name': 'la casa'
+          }
+      },
+      apiResults: [{ properties: {} }, { properties: { name: 'la casa' }}],
+      testCase: {
+        expected: {
+          properties: [
+              'my home'
+          ]
+        }
+      },
+      expected: 'pass'
+    },
+    {
       description: 'Test case with no `locations.json` props identified as a placeholder.',
       priorityThresh: -1,
       apiResults: [{ properties: {} }, { properties: { a: 1 }}],
@@ -182,7 +200,7 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
 
   tests.forEach( function ( testCase ){
     var result = evalTest(
-      testCase.priorityThresh, testCase.testCase, testCase.apiResults
+      testCase.priorityThresh, testCase.testCase, testCase.apiResults, testCase.locations
     );
     test.equal( result.result, testCase.expected, testCase.description );
   });

--- a/test/eval_test.js
+++ b/test/eval_test.js
@@ -195,14 +195,47 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
         }
       },
       expected: 'fail'
+    },
+    {
+      description: 'Weights can be set at the testSuite level',
+      priorityThresh: 3,
+      weights: {
+        properties: {
+          a: 50
+        }
+      },
+      apiResults: [
+        { properties: {a:1, b:2} },
+        { properties: {a:4, b:6} }
+      ],
+      testCase: {
+        expected: {
+          properties: [
+            {a:1, b:2},
+            {a:4, b:6}
+          ]
+        }
+      },
+      expected: 'pass',
+      expected_score: 104 // 2x 50 for a, 2x1 for b, 2x1 for priorityThresh
     }
   ];
 
-  tests.forEach( function ( testCase ){
+  tests.forEach( function ( one_test ){
+    var context = {
+      priorityThresh: one_test.priorityThresh,
+      locations: one_test.locations,
+      weights: one_test.weights
+    };
+
     var result = evalTest(
-      testCase.priorityThresh, testCase.testCase, testCase.apiResults, testCase.locations
+      one_test.testCase, one_test.apiResults, context
     );
-    test.equal( result.result, testCase.expected, testCase.description );
+    test.equal( result.result, one_test.expected, one_test.description );
+
+    if (one_test.expected_score) {
+      test.equal( result.score, one_test.expected_score, 'score should be as expected');
+    }
   });
 
   test.end();

--- a/test/eval_test.js
+++ b/test/eval_test.js
@@ -126,6 +126,24 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
       expected: 'pass'
     },
     {
+      description: 'Expected blocks need not be specified in the order they appear in the api results',
+      priorityThresh: 3,
+      apiResults: [
+        { properties: {a:1, b:2} },
+        { properties: {a:3, b:5} },
+        { properties: {a:4, b:6} }
+      ],
+      testCase: {
+        expected: {
+          properties: [
+            {a:4, b:6},
+            {a:1, b:2}
+          ]
+        }
+      },
+      expected: 'pass'
+    },
+    {
       description: 'Only one of multiple expected blocks found should fail',
       priorityThresh: 3,
       apiResults: [

--- a/test/sanitiseTestCase.js
+++ b/test/sanitiseTestCase.js
@@ -2,7 +2,6 @@
 
 var tape = require( 'tape' );
 
-var deepDiff = require( 'deep-diff' );
 var sanitiseTestCase = require( '../lib/sanitiseTestCase' );
 
 tape( 'testCaseSanitiser', function ( test ){
@@ -78,10 +77,8 @@ tape( 'testCaseSanitiser', function ( test ){
       }
     };
 
-
-    // deep diff returns undefined if there are no differences
-    var result = deepDiff.diff(expected_testCase, sanitiseTestCase(testCase, locations));
-    t.equal(result, undefined, 'test case has location filled in');
+    var result = sanitiseTestCase(testCase, locations);
+    t.deepEqual(result, expected_testCase, 'test case has location filled in');
     t.end();
   });
 

--- a/test/sanitiseTestCase.js
+++ b/test/sanitiseTestCase.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var tape = require( 'tape' );
+
+var deepDiff = require( 'deep-diff' );
+var sanitiseTestCase = require( '../lib/sanitiseTestCase' );
+
+tape( 'testCaseSanitiser', function ( test ){
+  test.test( 'test case with no expected or unexpected block is placeholder', function( t ) {
+    var testCase = {};
+    var expected_message = 'Placeholder test: no `expected` or `unexpected` given';
+
+    t.equal(expected_message, sanitiseTestCase(testCase), 'return message specifies placeholder');
+    t.end();
+  });
+
+  test.test( 'test case with empty expected block is placeholder', function( t ) {
+    var testCase = { expected: {}};
+    var expected_message = 'Placeholder test: `expected` block is empty';
+
+    t.equal(expected_message, sanitiseTestCase(testCase), 'return message specifies placeholder');
+    t.end();
+  });
+
+  test.test( 'test case with expected block is not placeholder', function( t ) {
+    var testCase = {expected: {properties:[]}};
+
+    t.equal(testCase, sanitiseTestCase(testCase), 'test case returned unaltered');
+    t.end();
+  });
+
+  test.test( 'test case with unexpected block is not placeholder', function( t ) {
+    var testCase = {unexpected: {}};
+
+    t.equal(testCase, sanitiseTestCase(testCase), 'test case returned unaltered');
+    t.end();
+  });
+
+  test.test( 'test case with string in properties array and no locations marked as placeholder', function( t ) {
+    var testCase = {
+      expected: {
+        properties: [
+          'a place'
+        ]
+      }
+    };
+    var expected_message = 'Placeholder: no matches for a place in `locations.json`.';
+
+    t.equal(expected_message, sanitiseTestCase(testCase), 'return message specifies placeholder due to location');
+    t.end();
+  });
+
+  test.test( 'test case with string in properties array and matching location replaces string', function( t ) {
+    var testCase = {
+      expected: {
+        properties: [
+          'a real place'
+        ]
+      }
+    };
+    var locations = {
+      'a real place': {
+        'name': 'a real place',
+        'admin0': 'USA',
+        'admin1': 'New York'
+      }
+    };
+
+    var expected_testCase = {
+      expected: {
+        properties: [
+          {
+            'name': 'a real place',
+            'admin0': 'USA',
+            'admin1': 'New York'
+          }
+        ]
+      }
+    };
+
+
+    // deep diff returns undefined if there are no differences
+    var result = deepDiff.diff(expected_testCase, sanitiseTestCase(testCase, locations));
+    t.equal(result, undefined, 'test case has location filled in');
+    t.end();
+  });
+
+  test.end();
+});

--- a/test/scoreProperties.js
+++ b/test/scoreProperties.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var tape = require( 'tape' );
+
+var scoreProperties = require( '../lib/scoreProperties' );
+
+tape( 'scoreProperties', function ( test ){
+
+  test.test('single matching primitive', function ( t ){
+    var expectation = 'a string';
+    var result = 'a string';
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 1, 'max score equals 1');
+    t.equal(score_result.score, 1, 'score equals 1');
+
+    t.end();
+  });
+
+  test.test('single unmatching primitive', function ( t ){
+    var expectation = 'a string';
+    var result = 'a different string';
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 1, 'max score equals 1');
+    t.equal(score_result.score, 0, 'score equals 0');
+
+    t.end();
+  });
+
+  test.test('object with single matching primitive property', function ( t ){
+    var expectation = { foo: 'a string' };
+    var result = { foo: 'a string' };
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 1, 'max score equals 1');
+    t.equal(score_result.score, 1, 'score equals 1');
+
+    t.end();
+  });
+
+  test.test('object with single mismatching primitive property', function ( t ){
+    var expectation = { foo: 'a string' };
+    var result = { foo:'a different string' };
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 1, 'max score equals 1');
+    t.equal(score_result.score, 0, 'score equals 0');
+
+    t.end();
+  });
+
+  test.test('object with matching and mismatching properties', function ( t ) {
+    var expectation = { foo: 'a string', bar: 'another string' };
+    var result = { foo:'a different string', bar: 'another string' };
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 2, 'max score equals 2');
+    t.equal(score_result.score, 1, 'score equals 1');
+
+    t.end();
+  });
+
+  test.test('object with nested object and matching properties', function ( t ) {
+    var expectation = { foo: 'a string', bar: { baz: 'another string' } };
+    var result = { foo:'a string', bar: { baz: 'another string' } };
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 2, 'max score equals 2');
+    t.equal(score_result.score, 2, 'score equals 2');
+
+    t.end();
+  });
+
+  test.test('object with nested object and matching and mismatching properties', function ( t ) {
+    var expectation = { foo: 'a string', bar: { baz: 'another string', wrong: 'expected value' } };
+    var result = { foo:'a string', bar: { baz: 'another string', wrong: 'unexpected value' } };
+
+    var score_result = scoreProperties(expectation, result);
+
+    t.equal(score_result.max_score, 3, 'max score equals 3');
+    t.equal(score_result.score, 2, 'score equals 2');
+
+    t.end();
+  });
+
+  test.end();
+});

--- a/test/scoreProperties.js
+++ b/test/scoreProperties.js
@@ -4,7 +4,7 @@ var tape = require( 'tape' );
 
 var scoreProperties = require( '../lib/scoreProperties' );
 
-tape( 'scoreProperties', function ( test ){
+tape( 'scoreProperties basics', function ( test ){
 
   test.test('single matching primitive', function ( t ){
     var expectation = 'a string';
@@ -86,6 +86,63 @@ tape( 'scoreProperties', function ( test ){
 
     t.equal(score_result.max_score, 3, 'max score equals 3');
     t.equal(score_result.score, 2, 'score equals 2');
+
+    t.end();
+  });
+
+  test.end();
+});
+
+
+tape( 'scoreProperties with weights', function ( test ){
+  test.test('single matching weighted primitive', function ( t ){
+    var expectation = 'a string';
+    var result = 'a string';
+    var weight = 5;
+
+    var score_result = scoreProperties(expectation, result, weight);
+
+    t.equal(score_result.max_score, 5, 'max score equals 5');
+    t.equal(score_result.score, 5, 'score equals 5');
+
+    t.end();
+  });
+
+  test.test('single unmatching weighted primitive', function ( t ){
+    var expectation = 'a string';
+    var result = 'a different string';
+    var weight = 5;
+
+    var score_result = scoreProperties(expectation, result, weight);
+
+    t.equal(score_result.max_score, 5, 'max score equals 5');
+    t.equal(score_result.score, 0, 'score equals 0');
+
+    t.end();
+  });
+
+  test.test('object with nested object and matching properties with weight', function ( t ) {
+    var expectation = { foo: 'a string', bar: { baz: 'another string' } };
+    var result = { foo:'a string', bar: { baz: 'another string' } };
+    var weight = { foo: 5, bar: { baz: 3}};
+
+    var score_result = scoreProperties(expectation, result, weight);
+
+    t.equal(score_result.max_score, 8, 'max score equals 8');
+    t.equal(score_result.score, 8, 'score equals 8');
+
+    t.end();
+  });
+
+  test.test('object with nested object and matching and mismatching properties', function ( t ) {
+    var expectation = { foo: 'a string', bar: { baz: 'another string', wrong: 'expected value' } };
+    var result = { foo:'a string', bar: { baz: 'another string', wrong: 'unexpected value' } };
+    var weight = { foo: 5, bar: { baz: 3, wrong: 2}};
+
+    var score_result = scoreProperties(expectation, result, weight);
+
+    t.equal(score_result.max_score, 10, 'max score equals 10');
+    t.equal(score_result.score, 8, 'score equals 8');
 
     t.end();
   });

--- a/test/test.js
+++ b/test/test.js
@@ -8,3 +8,4 @@ require('./exec_test_suite');
 require('./ExponentialBackoff');
 require('./eval_test');
 require('./equal_properties');
+require('./scoreProperties');

--- a/test/test.js
+++ b/test/test.js
@@ -8,4 +8,5 @@ require('./exec_test_suite');
 require('./ExponentialBackoff');
 require('./eval_test');
 require('./equal_properties');
+require('./sanitiseTestCase');
 require('./scoreProperties');


### PR DESCRIPTION
As described in the [fuzzy tests story](https://github.com/pelias/acceptance-tests/issues/109), this PR adds a ton of functionality to enable individual tests to be evaluated not just on a pass fail, but by a numeric score that can be influenced by specifying weights for individual values.

In addition there is a TON of refactoring that was very needed to make this change easy. There are now lots of individual files with very focused responsiblity, lots of unit tests, and lots of comments.

Fixes #2 
