### PR TITLE
Remove regression concept

### DIFF
--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -119,15 +119,6 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
       ));
 
       var results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
-      if( results.result === 'pass' && testCase.status === 'fail' ){
-        results.progress = 'improvement';
-      }
-      else if( results.result === 'fail' && testCase.status === 'pass' ){
-        // subtract the regression from fail count, so we don't double count them
-        testResults.stats.fail--;
-        testResults.stats.regression++;
-        results.progress = 'regression';
-      }
 
       results.testCase = testCase;
       results.response = res;

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -19,9 +19,8 @@ function prettyPrintResult( result ){
       break;
 
     case 'fail':
-      var color = (result.progress === 'regression') ? 'red' : 'yellow';
       console.error(
-        util.format( '  ✘ %s[%s] "%s": %s', status, id, input, result.msg )[ color ]
+        util.format( '  ✘ %s[%s] "%s": %s', status, id, input, result.msg ).red
       );
       break;
 
@@ -50,25 +49,23 @@ function prettyPrintSuiteResults( suiteResults ){
 
   console.log( '\nAggregate test results'.blue );
   console.log( 'Pass: ' + suiteResults.stats.pass.toString().green );
-  console.error( 'Fail: ' + suiteResults.stats.fail.toString().yellow );
+  console.error( 'Fail: ' + suiteResults.stats.fail.toString().red );
   console.error( 'Placeholders: ' + suiteResults.stats.placeholder.toString().cyan );
 
-  var numRegressions = suiteResults.stats.regression;
-  var regressionsColor = ( numRegressions > 0 ) ? 'red' : 'yellow';
-  var total = suiteResults.stats.pass +  suiteResults.stats.fail + suiteResults.stats.regression;
-  var pass = total - numRegressions;
+  var numFail = suiteResults.stats.fail;
+  var total = suiteResults.stats.pass +  suiteResults.stats.fail;
+  var pass = suiteResults.stats.pass;
   var percentage = pass * 100.0 / total;
-  console.log( 'Regressions: ' + numRegressions.toString()[ regressionsColor ] );
   console.log( 'Took %sms', suiteResults.stats.timeTaken );
   console.log( 'Test success rate %s%%', Math.round(percentage).toString());
 
   console.log( '' );
-  if( numRegressions > 0 ){
-    console.error( 'FATAL ERROR: %s regression(s) detected.'.red.inverse, numRegressions );
+  if( numFail > 0 ){
+    console.error( 'FATAL ERROR: %s failures(s) detected.'.red.inverse, numFail );
     process.exit( 1 );
   }
   else {
-    console.log( '0 regressions detected. All good.' );
+    console.log( '0 failures detected. All good.' );
   }
 }
 


### PR DESCRIPTION
Previously, our test suite could expect tests to pass or fail, leading to 4 possible test outcomes:

Pass: test passed and we expected it to pass (colored green)
Improvement: test passed and we expected it to fail (also green)
Fail: test failed and we expected it to fail (colored yellow)
Regression: test failed and we expected it to pass (colored red)

I don't believe we need to do this anymore especially with the fuzzy-tests repo, so now there are two outcomes:
Pass: test passed (green)
Fail: test failed (red)

The status: [pass|fail] property in tests is now completely ignored.

Fixes pelias/acceptance-tests#56
