### PR TITLE
Improve test enqueuing with Exponential Backoff

### DIFF
--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -71,7 +71,8 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
   var totalTestsNum = testSuite.tests.length;
 
   var test_interval = new ExponentialBackoff();
-  var intervalId = setInterval( function (){
+  var intervalId;
+  var runOneTest = function (){
     if( testSuite.tests.length === 0 ){
       return;
     }
@@ -89,12 +90,11 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
       var retry_codes = [408, 413, 429];
       if( err ){
         console.error( err );
-        return;
+        testSuite.tests.push( testCase );
       }
       else if( retry_codes.indexOf(res.statusCode) !== -1 ){
-        test_interval.increaseBackoff();
         testSuite.tests.push( testCase );
-        return;
+        test_interval.increaseBackoff();
       }
       else if( res.statusCode !== 200 ){
         console.error( 'Unexpected status code %s, exiting.\n'.red, res.statusCode );
@@ -108,34 +108,34 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
         );
         console.error( '\nInvestigate manually:\n  curl %s', res.request.url.href );
         process.exit( 1 );
+      } else {
+        // no error or retry
+        test_interval.decreaseBackoff();
+
+        stats.testsCompleted++;
+        process.stderr.write( util.format(
+          '\rTests completed: %s/%s', stats.testsCompleted.toString().bold,
+          stats.testsTotal
+        ));
+
+        var results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
+        if( results.result === 'pass' && testCase.status === 'fail' ){
+          results.progress = 'improvement';
+        }
+        else if( results.result === 'fail' && testCase.status === 'pass' ){
+          // subtract the regression from fail count, so we don't double count them
+          testResults.stats.fail--;
+          testResults.stats.regression++;
+          results.progress = 'regression';
+        }
+
+        results.testCase = testCase;
+        results.response = res;
+        testResults.stats[ results.result ]++;
+        testResults.results.push( results );
       }
-
-      test_interval.decreaseBackoff();
-
-      stats.testsCompleted++;
-      process.stderr.write( util.format(
-        '\rTests completed: %s/%s', stats.testsCompleted.toString().bold,
-        stats.testsTotal
-      ));
-
-      var results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
-      if( results.result === 'pass' && testCase.status === 'fail' ){
-        results.progress = 'improvement';
-      }
-      else if( results.result === 'fail' && testCase.status === 'pass' ){
-        // subtract the regression from fail count, so we don't double count them
-        testResults.stats.fail--;
-        testResults.stats.regression++;
-        results.progress = 'regression';
-      }
-
-      results.testCase = testCase;
-      results.response = res;
-      testResults.stats[ results.result ]++;
-      testResults.results.push( results );
 
       if( testResults.results.length === totalTestsNum ){
-        clearInterval( intervalId );
         testResults.stats.timeTaken = new Date().getTime() - startTime;
 
         /**
@@ -145,9 +145,18 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
          */
         testResults.results.sort( testCaseSort );
         cb( testResults );
+      } else {
+        reenqueue();
       }
     });
-  }, test_interval.getBackoff());
+  };
+
+  var reenqueue = function reenqueue() {
+    clearInterval(intervalId);
+    intervalId = setInterval(runOneTest, test_interval.getBackoff());
+  };
+
+  reenqueue();
 }
 
 module.exports = execTestSuite;

--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -70,7 +70,7 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
   var startTime = new Date().getTime();
   var totalTestsNum = testSuite.tests.length;
 
-  var test_interval = new ExponentialBackoff();
+  var test_interval = new ExponentialBackoff(25, 3, 100);
   var intervalId;
   var runOneTest = function (){
     if( testSuite.tests.length === 0 ){


### PR DESCRIPTION
The ExponentialBackoff library is working great, but due to the way we were calling setTimeout, the interval between tests was never being adjusted. 

Fixes #7
