### PR TITLE
Count tests with HTTP errors as failures

### DIFF
--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -68,7 +68,7 @@ function getStatKey(results) {
 }
 
 function printRequestErrorMessage(testCase, res) {
-  console.error( 'Unexpected status code %s, exiting.\n'.red, res.statusCode );
+  console.error( 'Unexpected status code %s.\n'.red, res.statusCode );
   console.error(
     'Failed for test case:\n%s\n',
     JSON.stringify( testCase, undefined, 4 ).replace( /^|\n/g, '\n\t' )
@@ -132,12 +132,21 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
         testSuite.tests.push( testCase );
         test_interval.increaseBackoff();
       }
-      else if( res.statusCode !== 200 ){
-        printRequestErrorMessage(testCase, res);
-        process.exit( 1 );
-      } else {
-        // no error or retry
-        test_interval.decreaseBackoff();
+      else {
+        var results;
+
+        if( res.statusCode !== 200 ){
+          test_interval.increaseBackoff();
+          printRequestErrorMessage(testCase, res);
+
+          results = {
+            result: 'fail',
+            msg: 'Unexpected status code ' + res.statusCode
+          };
+        } else {
+          test_interval.decreaseBackoff();
+          results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
+        }
 
         stats.testsCompleted++;
         process.stderr.write( util.format(
@@ -145,7 +154,6 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
           stats.testsTotal
         ));
 
-        var results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
         results.progress = getTestCaseProgress(results, testCase);
 
         testResults.stats[ getStatKey(results) ]++;

--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -135,7 +135,10 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
       else {
         var results;
 
-        if( res.statusCode !== 200 ){
+        if( res.statusCode === 200 ){
+          test_interval.decreaseBackoff();
+          results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
+        } else { // unexpected (non 200 or retry) status code
           test_interval.increaseBackoff();
           printRequestErrorMessage(testCase, res);
 
@@ -143,9 +146,6 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
             result: 'fail',
             msg: 'Unexpected status code ' + res.statusCode
           };
-        } else {
-          test_interval.decreaseBackoff();
-          results = evalTest( testSuite.priorityThresh, testCase, res.body.features );
         }
 
         stats.testsCompleted++;


### PR DESCRIPTION
Currently, when fuzzy-tester gets back a response code that isn't 200(all good) or 429 and similar (explicit message from the server to retry), the entire test suite quits immediately. Since we occasionally have 500 and other errors, this means the test suite often fails.

We can't retry on ALL errors because it's possible the error isn't transient and thus the test suite would never finish.

What we can do is at least run all the other tests, and count the test with unexpected error messages as a failure.

Fixes #8 

Note I intentionally didn't spend a huge amount of time on this because I think the code here should just be completely refactored. I'd rather fix this bug and then not have to rush that refactoring though.
