### PR TITLE
API key loaded from config file

### DIFF
--- a/lib/apiKey.js
+++ b/lib/apiKey.js
@@ -1,0 +1,15 @@
+var url = require('url'),
+    config = require('pelias-config');
+
+module.exports = function( uri ){
+
+  var settings = config.generate();
+
+  if( settings && settings.hasOwnProperty('mapzen') ){
+    var host = url.parse( uri ).host;
+    if( settings.mapzen.hasOwnProperty('api_key') && settings.mapzen.api_key.hasOwnProperty(host) ){
+      return settings.mapzen.api_key[ host ];
+    }
+  }
+  return null;
+};

--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+var apiKey = require( '../lib/apiKey' );
 var evalTest = require( '../lib/eval_test' );
 var ExponentialBackoff = require( '../lib/ExponentialBackoff');
 var request = require( 'request' );
@@ -122,6 +123,12 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
     }
 
     var testCase = testSuite.tests.pop();
+
+    // load api_key from pelias config
+    var key = apiKey( apiUrl );
+    if( key ){
+      testCase.in.api_key = key;
+    }
 
     var requestOpts = {
       url: testCase.endpoint || testSuite.endpoint || 'search',

--- a/test/apiKey.js
+++ b/test/apiKey.js
@@ -1,0 +1,69 @@
+var apiKey = require( '../lib/apiKey' );
+var fs = require( 'fs' );
+var tape = require( 'tape' );
+
+tape( 'api_key not found in config', function ( test ){
+
+  var config = '{}';
+
+  // write a temporary pelias config
+  fs.writeFileSync( '/tmp/pelias_temp.json', config, 'utf8' );
+
+  // set the PELIAS_CONFIG env var
+  process.env.PELIAS_CONFIG = '/tmp/pelias_temp.json';
+
+  // staging
+  test.equal( apiKey( 'http://pelias.stage.mapzen.com/foo' ), null, 'api key not found' );
+
+  // unset the PELIAS_CONFIG env var
+  delete process.env.PELIAS_CONFIG;
+
+  // delete temp file
+  fs.unlink( '/tmp/pelias_temp.json' );
+
+  test.end();
+});
+
+tape( 'stage api_key imported from pelias config', function ( test ){
+
+  var config = '{ "mapzen": { "api_key": { "pelias.stage.mapzen.com": "my_api_key" } } }';
+
+  // write a temporary pelias config
+  fs.writeFileSync( '/tmp/pelias_temp2.json', config, 'utf8' );
+
+  // set the PELIAS_CONFIG env var
+  process.env.PELIAS_CONFIG = '/tmp/pelias_temp2.json';
+
+  // staging
+  test.equal( apiKey( 'http://pelias.stage.mapzen.com/foo' ), 'my_api_key', 'api key loaded' );
+
+  // unset the PELIAS_CONFIG env var
+  delete process.env.PELIAS_CONFIG;
+
+  // delete temp file
+  fs.unlink( '/tmp/pelias_temp2.json' );
+
+  test.end();
+});
+
+tape( 'avoid matching partial urls', function ( test ){
+
+  var config = '{ "mapzen": { "api_key": { "pelias.stage.mapzen.com": "my_api_key" } } }';
+
+  // write a temporary pelias config
+  fs.writeFileSync( '/tmp/pelias_temp3.json', config, 'utf8' );
+
+  // set the PELIAS_CONFIG env var
+  process.env.PELIAS_CONFIG = '/tmp/pelias_temp3.json';
+
+  // staging
+  test.equal( apiKey( 'http://mapzen.com/foo' ), null, 'api not found' );
+
+  // unset the PELIAS_CONFIG env var
+  delete process.env.PELIAS_CONFIG;
+
+  // delete temp file
+  fs.unlink( '/tmp/pelias_temp3.json' );
+
+  test.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+require('./apiKey');
 require('./exec_test_suite');
 require('./ExponentialBackoff');
 require('./eval_test');


### PR DESCRIPTION
It's time to finally merge a 3 month old commit by @missinglink, with a few tweaks by yours truly.

This code allows API keys for various hosts to be specified in pelias.json. Here's an example config fragment: 

```
    "mapzen": {
            "api_key": {
                    "pelias.mapzen.com": "pelias-prod-XXXXXXX"
            }
    },
```

Besides being able to determine how often we are running tests, this change takes advantage of the higher rate limits given to production keys, so acceptance tests run almost twice as fast!

cherry-picked from e28bf93 from pelias/acceptance-tests

Conflicts:
    run_tests.js
    test/test.js
