### PR TITLE
handle database timeouts

### DIFF
--- a/lib/exec_test_suite.js
+++ b/lib/exec_test_suite.js
@@ -147,6 +147,11 @@ function execTestSuite( apiUrl, testSuite, stats, cb ){
         testSuite.tests.push( testCase );
         test_interval.increaseBackoff();
       }
+      else if( res && res.body && res.body.geocoding && Array.isArray( res.geocoding.errors ) &&
+               res.geocoding.errors[0] === 'Request Timeout after 3000ms' ){
+        testSuite.tests.push( testCase );
+        test_interval.increaseBackoff();
+      }
       else {
         var results;
 


### PR DESCRIPTION
hey @orangejulius I've been noticing a bunch of my test cases failing with the message `"no results returned"` against the `v1` code.

the error is caused when the elasticsearch client times out a query with the message `"Request Timeout after 3000ms"`, we used to return `statusCode:500` for this error _but_ now we return `statusCode:200` and `features: []` with the message parroted back to the user in the geojson as `res.geocoding.errors[0]`

eg.

``` bash
  "statusCode": 200,
  "body": {
    "geocoding": {
...
      "errors": [
        "Request Timeout after 3000ms"
      ],
...
    "type": "FeatureCollection",
    "features": []
  },
```

this PR is not really that nice (code wise) so that's totally open for a rewrite but at least it shows a place in the code where we may be able to handle this case and maybe retry those queries? I guess we wouldn't want to retry them indefinitely; because DOS.

thoughts?
