### PR TITLE
2-stage test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .validate.json
 errors-*.json
 fail_*.json
+history.json

--- a/fetch.js
+++ b/fetch.js
@@ -4,7 +4,6 @@ var TestCase = require('./lib/TestCase'),
     LocalDataStore = require('./lib/LocalDataStore');
 
 var report = require('./lib/reporter/status');
-
 var client = new HttpClient();
 
 function load( filename ){
@@ -17,27 +16,7 @@ function load( filename ){
 }
 
 var files = process.argv.slice(2);
-if( !files.length ){
-  files = [
-    '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json',
-    '/var/www/pelias/acceptance-tests/test_cases/address_type.json',
-    '/var/www/pelias/acceptance-tests/test_cases/admin_lookup.json',
-    '/var/www/pelias/acceptance-tests/test_cases/categories.json',
-    '/var/www/pelias/acceptance-tests/test_cases/exact_matches.json',
-    '/var/www/pelias/acceptance-tests/test_cases/landmarks.json',
-    '/var/www/pelias/acceptance-tests/test_cases/params_details.json',
-    '/var/www/pelias/acceptance-tests/test_cases/quattroshapes_popularity.json',
-    '/var/www/pelias/acceptance-tests/test_cases/reverse_categories.json',
-    '/var/www/pelias/acceptance-tests/test_cases/search_coarse.json',
-    '/var/www/pelias/acceptance-tests/test_cases/search.json',
-    '/var/www/pelias/acceptance-tests/test_cases/suggest_coarse.json',
-    '/var/www/pelias/acceptance-tests/test_cases/suggest.json',
-    '/var/www/pelias/acceptance-tests/test_cases/suggest_nearby.json'
-  ].reverse();
-}
-
 files.forEach( load );
-// load( '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json' );
 
 var store = new LocalDataStore({ path: './history.json' });
 client.on( 'transaction', store.put.bind( store ) );

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,53 @@
+
+var TestCase = require('./lib/TestCase'),
+    HttpClient = require('./lib/HttpClient'),
+    LocalDataStore = require('./lib/LocalDataStore');
+
+var report = require('./lib/reporter/status');
+
+var client = new HttpClient();
+
+function load( filename ){
+  var file = require( filename );
+  var testcase = TestCase.fromJson( file );
+
+  testcase.tests.forEach( function( test ){
+    client.enqueue(test.params);
+  });
+}
+
+var files = process.argv.slice(2);
+if( !files.length ){
+  files = [
+    '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json',
+    '/var/www/pelias/acceptance-tests/test_cases/address_type.json',
+    '/var/www/pelias/acceptance-tests/test_cases/admin_lookup.json',
+    '/var/www/pelias/acceptance-tests/test_cases/categories.json',
+    '/var/www/pelias/acceptance-tests/test_cases/exact_matches.json',
+    '/var/www/pelias/acceptance-tests/test_cases/landmarks.json',
+    '/var/www/pelias/acceptance-tests/test_cases/params_details.json',
+    '/var/www/pelias/acceptance-tests/test_cases/quattroshapes_popularity.json',
+    '/var/www/pelias/acceptance-tests/test_cases/reverse_categories.json',
+    '/var/www/pelias/acceptance-tests/test_cases/search_coarse.json',
+    '/var/www/pelias/acceptance-tests/test_cases/search.json',
+    '/var/www/pelias/acceptance-tests/test_cases/suggest_coarse.json',
+    '/var/www/pelias/acceptance-tests/test_cases/suggest.json',
+    '/var/www/pelias/acceptance-tests/test_cases/suggest_nearby.json'
+  ].reverse();
+}
+
+files.forEach( load );
+// load( '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json' );
+
+var store = new LocalDataStore({ path: './history.json' });
+client.on( 'transaction', store.put.bind( store ) );
+client.fetch();
+
+// reporter
+client.on( 'transaction', function( transaction ){
+  report( transaction.status );
+});
+
+client.on( 'done', function(){
+  process.stdout.write('\n');
+});

--- a/info.js
+++ b/info.js
@@ -1,0 +1,13 @@
+
+var LocalDataStore = require('./lib/LocalDataStore');
+var store = new LocalDataStore({ path: './history.json' });
+
+function find( hash ){
+  var hit = store.get( hash );
+  if( !hit ){
+    return console.error( 'not found!' );
+  }
+  console.log( JSON.stringify( hit, null, 2 ) );
+}
+
+process.argv.slice(2).forEach( find );

--- a/lib/ExponentialBackoff.js
+++ b/lib/ExponentialBackoff.js
@@ -9,18 +9,18 @@
  * @param {number} starting_backoff the backoff between the first and second request. defaults to * 50ms
  */
 var ExponentialBackoff = function(minimum_backoff, exponent, starting_backoff) {
-    this.minimum_backoff = minimum_backoff || 50;
-    this.exponent = exponent || 2.0;
-    this.starting_backoff = starting_backoff || this.minimum_backoff;
+  this.minimum_backoff = minimum_backoff || 50;
+  this.exponent = exponent || 2.0;
+  this.starting_backoff = starting_backoff || this.minimum_backoff;
 
-    this.backoff = this.starting_backoff;
+  this.backoff = this.starting_backoff;
 };
 
 /**
  * Get the current backoff as a simple number
  */
 ExponentialBackoff.prototype.getBackoff = function getBackoff() {
-    return this.backoff;
+  return this.backoff;
 };
 
 
@@ -29,7 +29,7 @@ ExponentialBackoff.prototype.getBackoff = function getBackoff() {
  * that would indicate a slowdown is needed, such as a failed request.
  */
 ExponentialBackoff.prototype.increaseBackoff = function increaseBackoff() {
-    this.backoff *= this.exponent;
+  this.backoff *= this.exponent;
 };
 
 /**
@@ -37,11 +37,11 @@ ExponentialBackoff.prototype.increaseBackoff = function increaseBackoff() {
  * value. This should be called when things are going smoothly, such as after a successful request.
  */
 ExponentialBackoff.prototype.decreaseBackoff = function decreaseBackoff() {
-    if (this.backoff <= this.minimum_backoff) {
-        this.backoff = this.minimum_backoff;
-    } else {
-        this.backoff /= this.exponent;
-    }
+  if (this.backoff <= this.minimum_backoff) {
+    this.backoff = this.minimum_backoff;
+  } else {
+    this.backoff /= this.exponent;
+  }
 };
 
 module.exports = ExponentialBackoff;

--- a/lib/HttpClient.js
+++ b/lib/HttpClient.js
@@ -1,0 +1,56 @@
+
+var EventEmitter = require('events').EventEmitter,
+    limit = require('simple-rate-limiter'),
+    request = require('request'),
+    merge = require('merge'),
+    util = require('util');
+
+function HttpClient( transport, options ){
+  EventEmitter.call(this);
+  this._queries = [];
+  this._transactions = [];
+  this.on( 'response', this._transaction.bind(this) );
+  this.options = merge( true, { throttle: 3 }, options || {} );
+
+  // configure rate limiter
+  this.transport = transport || limit(request)
+    .to(this.options.throttle)
+    .per(1200);
+}
+
+util.inherits( HttpClient, EventEmitter );
+
+HttpClient.prototype.enqueue = function( query ){
+  this._queries.push( query );
+  this.emit( 'enqueue', query );
+};
+
+HttpClient.prototype._request = function( query ){
+  this.emit( 'request', query );
+  this.transport( query, function( err, res, body ){
+    this.emit( 'response', query, err, res, body );
+  }.bind(this));
+};
+
+HttpClient.prototype._transaction = function( query, err, res, body ){
+  var transaction = {
+    status: res && res.statusCode || 900,
+    query: query,
+    err: err,
+    res: res,
+    body: body,
+    time: new Date().getTime()
+  };
+  this._transactions.push(transaction);
+  this.emit( 'transaction', transaction );
+  if( this._transactions.length === this._queries.length ){
+    this.emit( 'done', this._transactions );
+  }
+};
+
+HttpClient.prototype.fetch = function(){
+  this._transactions = []; // reset
+  this._queries.forEach( this._request.bind(this) );
+};
+
+module.exports = HttpClient;

--- a/lib/LocalDataStore.js
+++ b/lib/LocalDataStore.js
@@ -1,0 +1,49 @@
+
+var fs = require('fs'),
+    path = require('path');
+
+var naivedb = require('naivedb');
+var TestCase = require('./TestCase');
+
+function LocalDataStore( opts ){
+  this.opts = opts;
+  this.db = null;
+  this.open();
+}
+
+LocalDataStore.prototype.put = function( transaction ){
+  var hash = TestCase.hash( transaction.query ),
+      hit = this.db.get( hash );
+  
+  // initialize query in db
+  if( !hit ){
+    hit = { query: transaction.query, results: {} };
+  }
+
+  // add transaction to db  
+  hit.results[ transaction.time ] = {
+    status: transaction.status,
+    res: transaction.res,
+    err: transaction.err
+  };
+
+  this.db.set( hash, hit );
+};
+
+LocalDataStore.prototype.get = function( hash ){
+  return this.db.get( hash );
+};
+
+LocalDataStore.prototype.open = function(){
+  var dbpath = path.resolve( this.opts.path );
+  if( !fs.existsSync( dbpath ) ){
+    fs.writeFileSync( dbpath, '{}' ); // initdb
+  }
+  try {
+    this.db = naivedb( dbpath );
+  } catch( e ) {
+    throw new Error( 'invalid json: ' + dbpath );
+  }
+};
+
+module.exports = LocalDataStore;

--- a/lib/Score.js
+++ b/lib/Score.js
@@ -1,0 +1,77 @@
+
+var SHOW_HISTORY = 10;
+
+function Score( testcase, history ){
+  this.testcase = testcase;
+  this.history = history;
+  this.assertions = [];
+
+  this.status = Score.status.UNKNOWN;
+}
+
+Score.status = {
+  SAME:           620,
+  WORSE:          621,
+  BETTER:         622,
+  FAIL:           700,
+  NO_ASSERTIONS:  710,
+  UNKNOWN:        799
+};
+
+Score.prototype.assertEach = function( cb ){
+
+  this.assertions = [];
+  
+  if( this.history && this.history.results ){
+
+    var chronology = Object.keys( this.history.results )
+      .sort()
+      .reverse()
+      .slice( 0, SHOW_HISTORY );
+
+    chronology.forEach( function( time ){
+      var transaction = this.history.results[time];
+      if( !transaction ){
+        this.assertions.push( Score.status.UNKNOWN );
+      } else {
+        this.assertions.push( cb( transaction ) || Score.status.UNKNOWN );
+      }
+    }, this);
+  }
+
+  this.status = Score.statusOf( this.assertions );
+};
+
+Score.statusOf = function( assertions ){
+
+  if( !assertions || !assertions.length ){
+    return Score.status.NO_ASSERTIONS;
+  }
+
+  var currentStatus = assertions[0];
+  var lastStatus = assertions[1] || currentStatus;
+
+  if( currentStatus === lastStatus ){
+    // same
+    return Score.status.SAME;
+  } else if( currentStatus > lastStatus ){
+    if( currentStatus > 399 ){
+      // hiccup
+      return Score.status.SAME;
+    }
+    // regression
+    return Score.status.WORSE;
+  } else if( currentStatus < lastStatus ){
+    if( lastStatus > 399 ){
+      // resolve hiccup
+      return Score.status.SAME;
+    }
+    // improvement
+    return Score.status.BETTER;
+  }
+
+  return Score.status.UNKNOWN;
+
+};
+
+module.exports = Score;

--- a/lib/ScoringEngine.js
+++ b/lib/ScoringEngine.js
@@ -30,24 +30,20 @@ ScoringEngine.prototype.score = function( testcase ){
 
           var expected = testcase.assertions[type][attr];
           plan++;
-
-          if( equality && body && expectedValue && expected ){
-            console.log( 'uncomment me' );
-          }
           
-          // if( body && body.features ){
-          //   var s = attr.split(':');
-          //   if( s.length === 1 ){
-          //     if( expectedValue === equality.obj( expected, body.features, s[0] ) ){
-          //       pass++;
-          //     }
-          //   }
-          //   if( s.length === 2 && s[0] === 'keys' ){
-          //     if( equality.key( expected, body.features, s[1], expectedValue ) ){
-          //       pass++;
-          //     }
-          //   }
-          // }
+          if( body && body.features ){
+            var s = attr.split(':');
+            if( s.length === 1 ){
+              if( expectedValue === equality.obj( expected, body.features, s[0] ) ){
+                pass++;
+              }
+            }
+            if( s.length === 2 && s[0] === 'keys' ){
+              if( equality.key( expected, body.features, s[1], expectedValue ) ){
+                pass++;
+              }
+            }
+          }
         }
       }
     }

--- a/lib/ScoringEngine.js
+++ b/lib/ScoringEngine.js
@@ -1,0 +1,83 @@
+
+var equalProperties = require('./equal_properties' );
+var Score = require('./Score' );
+var report = require('./reporter/score' );
+
+function ScoringEngine( config ){
+  this.store = config.store;
+}
+
+ScoringEngine.prototype.score = function( testcase ){
+  
+  var score = new Score( testcase, this.store.get( testcase.hash ) );
+
+  score.assertEach( function( transaction ){
+
+    var body = transaction.res.body;
+    var plan = 0, pass = 0;
+
+    if( testcase.assertions.hasOwnProperty('expected') ){
+
+      var expected = testcase.assertions.expected.properties;
+      plan += expected.length;
+
+      expected.forEach( function( properties ){
+        if( body && body.features ){
+          for( var i in body.features ){
+            var feature = body.features[i];
+
+            // console.log( properties, feature.properties );
+            var assert = equalProperties( properties, feature.properties );
+            if( assert ){
+              pass++;
+              break;
+            }
+          }
+        }
+      });
+    }
+
+    if( testcase.assertions.hasOwnProperty('unexpected') ){
+
+      var unexpected = testcase.assertions.unexpected.properties;
+      plan += unexpected.length;
+
+      unexpected.forEach( function( properties ){
+        if( body && body.features ){
+          for( var i in body.features ){
+            var feature = body.features[i];
+
+            // console.log( properties, feature.properties );
+            var assert = equalProperties( properties, feature.properties );
+            if( !assert ){
+              pass++;
+              break;
+            }
+          }
+        }
+      });
+    }
+
+    // service failure
+    if( transaction.status > 299 ){
+      return transaction.status;
+    }
+
+    // no assertions run
+    else if( plan === 0 ) {
+      return Score.status.NO_ASSERTIONS;
+    }
+    
+    // some assertions failed
+    if( pass !== plan ){
+      return Score.status.FAIL;
+    }
+
+    return transaction.status;
+  });
+
+  // reporter
+  report( score );
+};
+
+module.exports = ScoringEngine;

--- a/lib/ScoringEngine.js
+++ b/lib/ScoringEngine.js
@@ -1,7 +1,8 @@
 
-var equalProperties = require('./equal_properties' );
+
 var Score = require('./Score' );
 var report = require('./reporter/score' );
+var equality = require('./scorer/equality' );
 
 function ScoringEngine( config ){
   this.store = config.store;
@@ -14,48 +15,41 @@ ScoringEngine.prototype.score = function( testcase ){
   score.assertEach( function( transaction ){
 
     var body = transaction.res.body;
-    var plan = 0, pass = 0;
+    var plan = 0, pass = 0, attr;
 
-    if( testcase.assertions.hasOwnProperty('expected') ){
+    var assertionTypes = {
+      expected:   true,
+      unexpected: false
+    };
 
-      var expected = testcase.assertions.expected.properties;
-      plan += expected.length;
+    for( var type in assertionTypes ){
+      if( testcase.assertions.hasOwnProperty(type) ){
+        var expectedValue = assertionTypes[type];
+        for( attr in testcase.assertions[type] ){
+          // attr eg. properties
 
-      expected.forEach( function( properties ){
-        if( body && body.features ){
-          for( var i in body.features ){
-            var feature = body.features[i];
+          var expected = testcase.assertions[type][attr];
+          plan++;
 
-            // console.log( properties, feature.properties );
-            var assert = equalProperties( properties, feature.properties );
-            if( assert ){
-              pass++;
-              break;
-            }
+          if( equality && body && expectedValue && expected ){
+            console.log( 'uncomment me' );
           }
+          
+          // if( body && body.features ){
+          //   var s = attr.split(':');
+          //   if( s.length === 1 ){
+          //     if( expectedValue === equality.obj( expected, body.features, s[0] ) ){
+          //       pass++;
+          //     }
+          //   }
+          //   if( s.length === 2 && s[0] === 'keys' ){
+          //     if( equality.key( expected, body.features, s[1], expectedValue ) ){
+          //       pass++;
+          //     }
+          //   }
+          // }
         }
-      });
-    }
-
-    if( testcase.assertions.hasOwnProperty('unexpected') ){
-
-      var unexpected = testcase.assertions.unexpected.properties;
-      plan += unexpected.length;
-
-      unexpected.forEach( function( properties ){
-        if( body && body.features ){
-          for( var i in body.features ){
-            var feature = body.features[i];
-
-            // console.log( properties, feature.properties );
-            var assert = equalProperties( properties, feature.properties );
-            if( !assert ){
-              pass++;
-              break;
-            }
-          }
-        }
-      });
+      }
     }
 
     // service failure

--- a/lib/Suite.js
+++ b/lib/Suite.js
@@ -1,0 +1,29 @@
+
+// var HttpClient = require('./HttpClient'),
+//     LocalDataStore = require('./LocalDataStore');
+
+// function Suite(){
+//   this._cases = [];
+// }
+
+// Suite.prototype.add = function( testcase ){
+//   this._cases.push( testcase );
+// };
+
+// Suite.prototype.fetch = function( client, cb ){
+//   this._queue.forEach( function( testcase ){
+//     client.enqueue({ qs: testcase.req });
+//   });
+
+//   client.fetch( cb );
+// };
+
+// Suite.prototype.persist = function( engine, cb ){
+//   this._queue.forEach( function( testcase ){
+//     client.enqueue({ qs: testcase.req });
+//   });
+
+//   client.fetch( cb );
+// };
+
+// module.exports = Suite;

--- a/lib/TestCase.js
+++ b/lib/TestCase.js
@@ -1,0 +1,79 @@
+
+var merge = require('merge'),
+    hash = require('object-hash');
+
+var defaults = {
+  options: {
+    priorityThresh: 3
+  },
+  params: {
+    baseUrl: 'http://pelias.mapzen.com',
+    url: 'search',
+    json: true
+  }
+};
+
+function TestCase( name, options, params ){
+  this.name = name;
+  this.options = merge( true, defaults.options, options || {});
+  this.params = merge( true, defaults.params, params || {} );
+  this.tests = [];
+}
+
+TestCase.hash = function( obj ){
+  return hash.sha1( obj ).substring(0,8);
+};
+
+TestCase.prototype.addTest = function( info, params, assertions ){
+  var mergedParams = merge( true, this.params, params || {} );
+  this.tests.push({
+    hash: TestCase.hash( mergedParams ),
+    info: info,
+    params: mergedParams,
+    assertions: assertions
+  });
+};
+
+TestCase.fromJson = function( json ){
+  
+  if( !json.hasOwnProperty('name') ||
+      !Array.isArray( json.tests ) ){
+    throw new Error( 'invalid testcase json' );
+  }
+
+  var options = {};
+  if( json.hasOwnProperty('priorityThresh') ){
+    options.priorityThresh = json.priorityThresh;
+  }
+
+  var params = {};
+  if( json.hasOwnProperty('endpoint') ){
+    params.url = json.endpoint; // @todo: these properties are unintuitive
+  }
+
+  var testcase = new TestCase( json.name, options, params );
+
+  json.tests.forEach( function( test ){
+
+    var info = { user: test.user };
+    var params = { qs: test.in };
+
+    var assertions = {};
+    if( test.hasOwnProperty('expected') ){
+      assertions.expected = test.expected;
+    }
+    if( test.hasOwnProperty('unexpected') ){
+      assertions.unexpected = test.unexpected;
+    }
+
+    if( test.hasOwnProperty('endpoint') ){
+      params.url = test.endpoint; // @todo: these properties are unintuitive
+    }
+
+    testcase.addTest( info, params, assertions );
+  });
+
+  return testcase;
+};
+
+module.exports = TestCase;

--- a/lib/TestCase.js
+++ b/lib/TestCase.js
@@ -7,7 +7,7 @@ var defaults = {
     priorityThresh: 3
   },
   params: {
-    baseUrl: 'http://pelias.mapzen.com',
+    baseUrl: 'http://pelias.bigdev.mapzen.com',
     url: 'search',
     json: true
   }
@@ -61,6 +61,13 @@ TestCase.fromJson = function( json ){
     var assertions = {};
     if( test.hasOwnProperty('expected') ){
       assertions.expected = test.expected;
+
+      // @todo: this is just BAAAD
+      if( assertions.expected.hasOwnProperty('priorityThresh') ){
+        testcase.options.priorityThresh = assertions.expected.priorityThresh;
+        delete assertions.expected.priorityThresh;
+      }
+
     }
     if( test.hasOwnProperty('unexpected') ){
       assertions.unexpected = test.unexpected;

--- a/lib/reporter/score.js
+++ b/lib/reporter/score.js
@@ -25,6 +25,7 @@ module.exports = function( score ){
   }
 
   process.stdout.write(' ' + stringify( score.testcase.params.qs ) );
+  process.stdout.write(' /' + score.testcase.params.url );
   process.stdout.write('\n');
 
 };

--- a/lib/reporter/score.js
+++ b/lib/reporter/score.js
@@ -1,0 +1,30 @@
+
+var report = require('./status');
+
+// stringify 'input' param first
+var _stringify = require('json-stable-stringify');
+var stringify = function( obj ){
+  return _stringify( obj, function (a, b) {
+    if( a.key === 'input' ){ return -1; }
+    if( b.key === 'input' ){ return  1; }
+    return a.key < b.key ? 1 : -1;
+  });
+};
+
+module.exports = function( score ){
+
+  process.stdout.write( ' ' + report( score.status, true ) + ' ' );
+  process.stdout.write( '[' + score.testcase.hash + '] ' );
+
+  if( !score.assertions.length ){
+    report( 999 );
+  } else {
+    score.assertions.forEach( function( status ){
+      report( status );
+    });
+  }
+
+  process.stdout.write(' ' + stringify( score.testcase.params.qs ) );
+  process.stdout.write('\n');
+
+};

--- a/lib/reporter/status.js
+++ b/lib/reporter/status.js
@@ -1,0 +1,26 @@
+
+var Score = require('../Score');
+
+module.exports = function( status, dontPrint ){
+
+  var result;
+  
+  switch( status ){
+    case 200:
+    case 201: result = '·'; break;
+    case 408: result = 'T'; break; //timeout 
+    case 429: result = 'R'; break; //ratelimit
+    case Score.status.SAME: result = '-'; break;
+    case Score.status.WORSE: result = '▼'; break;
+    case Score.status.BETTER: result = '▲'; break;
+    case Score.status.FAIL: result = 'F'; break;
+    default: result = '?'; break;
+    //process.stdout.write( '' + Math.floor( status / 100 ) );
+  }
+
+  if( !dontPrint ){
+    process.stdout.write( result );
+  }
+
+  return result;
+};

--- a/lib/scorer/equality.js
+++ b/lib/scorer/equality.js
@@ -1,0 +1,39 @@
+
+var equalProperties = require('../equal_properties' );
+
+// cycle through each dict in the dicts array until a
+// match is found then return true, else return false
+
+function obj_scorer( dicts, features, attr ){
+  // attr eg. properties
+  var plan = dicts.length, pass = 0;
+  dicts.forEach( function( dict ){
+    for( var i in features ){
+      var feature = features[i];
+
+      // console.log( dict, feature.properties );
+      var assert = equalProperties( dict, feature[attr] );
+      if( assert ){ pass++; break; }
+    }
+  });
+  return pass === plan;
+}
+
+// cycle through all keys in the expected array ensuring
+// all keys are present in all features
+
+function key_scorer( keys, features, attr, expectedValue ){
+  var plan = 0, pass = 0;
+  features.forEach( function( feature ){
+    keys.forEach( function( key ){
+      plan++;
+      if( expectedValue === feature[attr].hasOwnProperty( key ) ){
+        pass++;
+      }
+    });
+  });
+  return pass === plan;
+}
+
+module.exports.key = key_scorer;
+module.exports.obj = obj_scorer;

--- a/package.json
+++ b/package.json
@@ -20,18 +20,24 @@
     "fuzzy-tester": "./bin/fuzzy-tester"
   },
   "dependencies": {
+    "async": "^1.4.0",
     "colors": "^1.x.x",
     "commander": "2.7.0",
     "fs-extra": "^0.22.1",
     "handlebars": "^3.x.x",
     "is-object": "^1.0.1",
+    "json-stable-stringify": "^1.0.0",
     "juice": "^1.x.x",
+    "merge": "^1.2.0",
+    "naivedb": "^1.0.7",
     "nodemailer": "^1.x.x",
     "nodemailer-ses-transport": "1.2.0",
+    "object-hash": "^0.8.0",
     "pelias-config": "^0.x.x",
     "request": "^2.55.0",
     "require-dir": "0.1.0",
-    "sanitize-filename": "^1.3.0"
+    "sanitize-filename": "^1.3.0",
+    "simple-rate-limiter": "^0.2.3"
   },
   "devDependencies": {
     "jshint": "^2.6.3",
@@ -54,6 +60,6 @@
     "test"
   ],
   "engines": {
-	  "npm": "~2.0.0"
+    "npm": "~2.0.0"
   }
 }

--- a/score.js
+++ b/score.js
@@ -16,26 +16,5 @@ function load( filename ){
   });
 }
 
-
 var files = process.argv.slice(2);
-if( !files.length ){
-  files = [
-    '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json',
-    '/var/www/pelias/acceptance-tests/test_cases/address_type.json',
-    '/var/www/pelias/acceptance-tests/test_cases/admin_lookup.json',
-    '/var/www/pelias/acceptance-tests/test_cases/categories.json',
-    '/var/www/pelias/acceptance-tests/test_cases/exact_matches.json',
-    '/var/www/pelias/acceptance-tests/test_cases/landmarks.json',
-    '/var/www/pelias/acceptance-tests/test_cases/params_details.json',
-    '/var/www/pelias/acceptance-tests/test_cases/quattroshapes_popularity.json',
-    '/var/www/pelias/acceptance-tests/test_cases/reverse_categories.json',
-    '/var/www/pelias/acceptance-tests/test_cases/search_coarse.json',
-    '/var/www/pelias/acceptance-tests/test_cases/search.json',
-    '/var/www/pelias/acceptance-tests/test_cases/suggest_coarse.json',
-    '/var/www/pelias/acceptance-tests/test_cases/suggest.json',
-    '/var/www/pelias/acceptance-tests/test_cases/suggest_nearby.json'
-  ].reverse();
-}
-
 files.forEach( load );
-// load( '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json' );

--- a/score.js
+++ b/score.js
@@ -1,0 +1,41 @@
+
+var TestCase = require('./lib/TestCase'),
+    ScoringEngine = require('./lib/ScoringEngine'),
+    LocalDataStore = require('./lib/LocalDataStore');
+
+var store = new LocalDataStore({ path: './history.json' });
+var engine = new ScoringEngine({ store: store });
+
+function load( filename ){
+  var file = require( filename );
+  var testcase = TestCase.fromJson( file );
+
+  console.log( '\n' + testcase.name );
+  testcase.tests.forEach( function( test ){
+    engine.score( test );
+  });
+}
+
+
+var files = process.argv.slice(2);
+if( !files.length ){
+  files = [
+    '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json',
+    '/var/www/pelias/acceptance-tests/test_cases/address_type.json',
+    '/var/www/pelias/acceptance-tests/test_cases/admin_lookup.json',
+    '/var/www/pelias/acceptance-tests/test_cases/categories.json',
+    '/var/www/pelias/acceptance-tests/test_cases/exact_matches.json',
+    '/var/www/pelias/acceptance-tests/test_cases/landmarks.json',
+    '/var/www/pelias/acceptance-tests/test_cases/params_details.json',
+    '/var/www/pelias/acceptance-tests/test_cases/quattroshapes_popularity.json',
+    '/var/www/pelias/acceptance-tests/test_cases/reverse_categories.json',
+    '/var/www/pelias/acceptance-tests/test_cases/search_coarse.json',
+    '/var/www/pelias/acceptance-tests/test_cases/search.json',
+    '/var/www/pelias/acceptance-tests/test_cases/suggest_coarse.json',
+    '/var/www/pelias/acceptance-tests/test_cases/suggest.json',
+    '/var/www/pelias/acceptance-tests/test_cases/suggest_nearby.json'
+  ].reverse();
+}
+
+files.forEach( load );
+// load( '/var/www/pelias/acceptance-tests/test_cases/address_parsing.json' );

--- a/test/ExponentialBackoff.js
+++ b/test/ExponentialBackoff.js
@@ -4,30 +4,30 @@ var tape = require( 'tape' );
 var ExponentialBackoff = require( '../lib/ExponentialBackoff' );
 
 tape( 'ExponentialBackoff', function(test) {
-    test.test( 'calling increaseBackoff() makes backoff larger', function(t) {
-        var eb = new ExponentialBackoff();
-        var startBackoff = eb.getBackoff();
-        eb.increaseBackoff();
-        t.ok(startBackoff < eb.getBackoff(), 'backoff was higher');
-        t.end();
-    });
+  test.test( 'calling increaseBackoff() makes backoff larger', function(t) {
+    var eb = new ExponentialBackoff();
+    var startBackoff = eb.getBackoff();
+    eb.increaseBackoff();
+    t.ok(startBackoff < eb.getBackoff(), 'backoff was higher');
+    t.end();
+  });
 
-    test.test( 'calling decreaseBackoff() lowers backoff', function(t) {
-        var eb = new ExponentialBackoff();
-        eb.increaseBackoff();
-        var startBackoff = eb.getBackoff();
-        eb.decreaseBackoff();
-        t.ok(startBackoff > eb.getBackoff(), 'backoff was lower');
-        t.end();
-    });
+  test.test( 'calling decreaseBackoff() lowers backoff', function(t) {
+    var eb = new ExponentialBackoff();
+    eb.increaseBackoff();
+    var startBackoff = eb.getBackoff();
+    eb.decreaseBackoff();
+    t.ok(startBackoff > eb.getBackoff(), 'backoff was lower');
+    t.end();
+  });
 
-    test.test( 'calling decreaseBackoff() will not lower backoff below minimum', function(t) {
-        var eb = new ExponentialBackoff();
-        var startBackoff = eb.getBackoff();
-        eb.decreaseBackoff();
-        t.ok(startBackoff === eb.getBackoff(), 'backoff was at minimum');
-        t.end();
-    });
+  test.test( 'calling decreaseBackoff() will not lower backoff below minimum', function(t) {
+    var eb = new ExponentialBackoff();
+    var startBackoff = eb.getBackoff();
+    eb.decreaseBackoff();
+    t.ok(startBackoff === eb.getBackoff(), 'backoff was at minimum');
+    t.end();
+  });
 
-    test.end();
+  test.end();
 });


### PR DESCRIPTION
this is the 2-stage test suite code that was discussed at mapzen-conf.

the idea behind this was that the suite would be run in 2 separate parts:

1) fetch the search results from the remote server and store them in a local file
2) process the historic data gathered from multiple executions of step 1.

the advantages were:
- step 1. can be time consuming, having results caches locally speeds up dev work
- historic results show change-over-time rather than a binary yes/no for each query
- easier handling of intermittent errors (such as shard failures, timeouts etc.)
- allows experimentation with different scoring algorithms and even frameworks as 1. and 2. are independant
- allows you to look through historic data when searches start to return 0 results, this is useful to check if the record was deleted in the source dataset.
