### PR TITLE
Make diff output more concise for failed tests

### DIFF
--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -7,11 +7,33 @@ var _ = require('lodash');
 var supportedNormalizers = require('../lib/normalizers');
 var compose = require('fj-compose');
 
+function formatDiff(diff) {
+  if (!diff) {
+    return '';
+  }
+
+  // remove any extra nesting in the array
+  while (_.isArray(diff) && diff.length === 1 && _.isArray(diff[0])) {
+    diff = diff[0];
+  }
+
+  var output = diff.map(function(diff_part) {
+    if (_.isString(diff_part)) {
+      return '    ' + diff_part;
+    }
+    return '    ' + diff_part.property +
+      '\n      expected: ' + diff_part.expected +
+      '\n      actual:   ' + diff_part.actual;
+  });
+
+  return output.join('\n');
+}
+
 function formatTestErrors(score) {
   var message = 'score ' + score.score + ' out of ' + score.max_score;
 
   if (score.score < score.max_score) {
-    message += '\ndiff: ' + JSON.stringify(score.diff, null, 2);
+    message += '\n  diff:\n' + formatDiff(score.diff);
   }
 
   return message;

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -29,7 +29,7 @@ function createDiff(expectation, result) {
       return {
         property: diff_part.path[0],
         expected: diff_part.lhs,
-        'actual  ': diff_part.rhs || ''
+        actual: diff_part.rhs || ''
       };
     }
 

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -17,9 +17,26 @@ function createDiff(expectation, result) {
 
   // filter out diff elements corresponding to a new element on the right side
   // these are ignored by our tests and would just be noise
-  return diff.filter(function(diff_part) {
+  diff = diff.filter(function(diff_part) {
     return diff_part.kind !== 'N';
   });
+
+
+  // Make the diff output more compact and use terminology that makes
+  // sense in a test concept (expectation/actual vs left/right side)
+  diff = diff.map(function(diff_part) {
+    if (diff_part.kind === 'E' || diff_part.kind === 'D') {
+      return {
+        property: diff_part.path[0],
+        expected: diff_part.lhs,
+        'actual  ': diff_part.rhs || ''
+      };
+    }
+
+    return diff_part;
+  });
+
+  return diff;
 }
 
 function filterDiffs(diff) {

--- a/lib/scoreProperties.js
+++ b/lib/scoreProperties.js
@@ -26,7 +26,7 @@ function scoreProperties(expectation, result, weight) {
       return scoreProperties(expectation[property], result[property], weight[property]);
     });
 
-    var diff = [helpers.createDiff(expectation, result)];
+    var diff = helpers.createDiff(expectation, result);
     return subscores.reduce(helpers.combineScores, { score: 0, max_score: 0, diff: diff});
   } else {
     return scorePrimitiveProperty(expectation, result, weight);


### PR DESCRIPTION
The previous output was more verbose than needed. When there are lots of
test, having the output more dense should help quite a bit.

Also, the terminology for the diff was very generic: lhs (left hand
side) vs rhs (right hand side). But in a testing context we can use
expected and actual to make the meaning more clear.

*\* Old output **
![old-diff](https://cloud.githubusercontent.com/assets/111716/11157633/8be8d984-8a20-11e5-981c-ee39c61f296b.png)

*\* New output **
![new-diff](https://cloud.githubusercontent.com/assets/111716/11157637/8f7ad50c-8a20-11e5-9bc1-6e05fe79bdd6.png)

Tweaks or other improvement suggestions welcome!
