### PR TITLE
Clone object to isolate testCase settings

### DIFF
--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -116,6 +116,7 @@ function composeNormalizer(normalizers) {
  * status of this test (whether it passed, failed, is a placeholder, etc.)
  */
 function evalTest( testCase, apiResults, context ){
+  context = _.clone(context);
   context = makeTestContext( testCase, context );
 
   testCase = sanitiseTestCase(testCase, context.locations);

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -116,7 +116,7 @@ function composeNormalizer(normalizers) {
  * status of this test (whether it passed, failed, is a placeholder, etc.)
  */
 function evalTest( testCase, apiResults, context ){
-  context = _.clone(context);
+  context = _.clone(context, true);
   context = makeTestContext( testCase, context );
 
   testCase = sanitiseTestCase(testCase, context.locations);


### PR DESCRIPTION
This is what was causing the variability in the Madrid autocomplete test: a previous test earlier in the file changed the priorityThresh setting, which was inadvertently leaking into later tests.
