### PR TITLE
Throw error when requested normalizer not found

### DIFF
--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -105,6 +105,9 @@ function makeTestContext( testCase, context ) {
 // for reduce, the seed value is a function that just returns the input
 function composeNormalizer(normalizers) {
   return normalizers.reverse().reduce(function(previousValue, currentValue) {
+    if(!supportedNormalizers[currentValue]) {
+      throw 'No normalizer called ' + currentValue + ' found';
+    }
       return compose(previousValue, supportedNormalizers[currentValue]);
   }, supportedNormalizers.identity);
 


### PR DESCRIPTION
There was no check that a normalizer listed in a test case or test suite
actaully existed, which lead to a very cryptic error when one was
missing:

```
julian@julian-mapzen ~/repos/pelias/fuzzy-tests $ ~/repos/pelias/fuzzy-tester/bin/fuzzy-tester florida_food_inspections_by_name.json
/home/julian/repos/pelias/fuzzy-tester/node_modules/fj-compose/index.js:14
      return f(g.apply(null, args));
                ^
TypeError: Cannot read property 'apply' of undefined
    at
/home/julian/repos/pelias/fuzzy-tester/node_modules/fj-compose/index.js:14:17
    at Object.name
(/home/julian/repos/pelias/fuzzy-tester/node_modules/fj-compose/index.js:14:14)
    at /home/julian/repos/pelias/fuzzy-tester/lib/eval_test.js:166:41
    at Array.forEach (native)
    at /home/julian/repos/pelias/fuzzy-tester/lib/eval_test.js:165:7
    at Array.map (native)
    at normalizeExpected
(/home/julian/repos/pelias/fuzzy-tester/lib/eval_test.js:158:63)
    at evalTest
(/home/julian/repos/pelias/fuzzy-tester/lib/eval_test.js:139:14)
    at Request._callback
(/home/julian/repos/pelias/fuzzy-tester/lib/exec_test_suite.js:172:21)
    at Request.self.callback
(/home/julian/repos/pelias/fuzzy-tester/node_modules/request/request.js:197:22)
```

Now they look like this:

```
julian@julian-mapzen ~/repos/pelias/fuzzy-tests $ ~/repos/pelias/fuzzy-tester/bin/fuzzy-tester florida_food_inspections_by_name.json

/home/julian/repos/pelias/fuzzy-tester/lib/eval_test.js:109
      throw "No normalizer called " + currentValue + " found";
                                                   ^
No normalizer called abbreviateStreetSuffexes found
```
