### PR TITLE
Output results only for tests with an expected result

### DIFF
--- a/output_generators/autocomplete.js
+++ b/output_generators/autocomplete.js
@@ -37,7 +37,7 @@ function getTestCaseTitleString(testCase) {
 
 function prettyPrintTestCase(testCase) {
   // filter out /reverse tests
-  if(testCase.in.text === undefined) {
+  if(testCase.in.text === undefined || !testCase.expected) {
     return;
   }
 


### PR DESCRIPTION
Tests that check that something is NOT in the resuls aren't as interesting for autocomplete, and currently cause an error in the output. 
