### PR TITLE
Fix truncation errors

### DIFF
--- a/bin/fuzzy-tester
+++ b/bin/fuzzy-tester
@@ -29,7 +29,7 @@ var analyze_results = require( '../lib/analyze_results' );
     // display results using the correct output generator
     var return_code = config.outputGenerator(evaled_results, config, testSuites);
 
-    process.exit(return_code);
+    process.exitCode = return_code;
   };
 
   // find all test suites and test cases that will be run

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -35,17 +35,17 @@ function prettyPrintResult( result ){
 
     case 'fail':
       var color = (result.progress === 'regression') ? 'red' : 'yellow';
-      console.error(
+      console.log(
         util.format( '  ✘ %s[%s] "%s": %s', status, id, testDescription, result.msg )[ color ]
       );
       break;
 
     case 'placeholder':
-      console.error( util.format( '  ! [%s] "%s": %s', id, testDescription, result.msg ).cyan );
+      console.log( util.format( '  ! [%s] "%s": %s', id, testDescription, result.msg ).cyan );
       break;
 
     default:
-      console.error( util.format( 'Result type `%s` not recognized.', result.result ) );
+      console.log( util.format( 'Result type `%s` not recognized.', result.result ) );
       process.exit( 1 );
       break;
   }
@@ -67,8 +67,8 @@ function prettyPrintSuiteResults( suiteResults, config, testSuites ){
 
   console.log( '\nAggregate test results'.blue );
   console.log( 'Pass: ' + suiteResults.stats.pass.toString().green );
-  console.error( 'Fail: ' + suiteResults.stats.fail.toString().yellow );
-  console.error( 'Placeholders: ' + suiteResults.stats.placeholder.toString().cyan );
+  console.log( 'Fail: ' + suiteResults.stats.fail.toString().yellow );
+  console.log( 'Placeholders: ' + suiteResults.stats.placeholder.toString().cyan );
 
   var numRegressions = suiteResults.stats.regression;
   var regressionsColor = ( numRegressions > 0 ) ? 'red' : 'yellow';
@@ -81,7 +81,7 @@ function prettyPrintSuiteResults( suiteResults, config, testSuites ){
 
   console.log( '' );
   if( numRegressions > 0 ){
-    console.error( 'FATAL ERROR: %s regression(s) detected.'.red.inverse, numRegressions );
+    console.log( 'FATAL ERROR: %s regression(s) detected.'.red.inverse, numRegressions );
     return 1;
   }
   else {


### PR DESCRIPTION
The output from the fuzzy-tester is sometimes truncated, it turns out `process.exit` is unsafe to use just after a bunch of big `console.log`s. Instead [process.exitCode](https://nodejs.org/api/process.html#process_process_exitcode) should be used. See these Node.js issues:

https://github.com/nodejs/node/issues/3669
https://github.com/nodejs/node/pull/3170
https://github.com/nodejs/node/issues/2972#issuecomment-146078649

~Note: after this is merged I'm going to backport it to the 0.5 branch and release 0.5.2 to be used with our acceptance tests right away~ Update: it doesn't need to be backported afterall!
