### PR TITLE
Improve unexpected output

### DIFF
--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -148,7 +148,7 @@ function evalTest( testCase, apiResults, context ){
   testCase = normalizeExpected(testCase, context.propertyNormalizers);
   apiResults = normalizeActual(apiResults, context.propertyNormalizers);
 
-  var score = scoreTest(testCase, apiResults, context);
+  var score = scoreTest.scoreTest(testCase, apiResults, context);
 
   return {
     result: (score.score < score.max_score) ? 'fail' : 'pass',

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -35,17 +35,21 @@ function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
 function scoreUnexpected(unexpected, apiResults, weight) {
   weight = weight || 1;
   // unexpected result should be absent from every returned result
-  var pass = apiResults.every(function(result) {
-    // if every unexpected input is not found, the tests pass
-    return unexpected.properties.every(function(property) {
-      return !equalProperties(property, result.properties);
+  var unexpectedResults = unexpected.properties.filter(function(property) {
+    return apiResults.some(function(result) {
+      return equalProperties(property, result.properties);
     });
+  });
+  var pass = unexpectedResults.length === 0;
+
+  var diff = unexpectedResults.map(function(result) {
+    return 'unexpected result found from ' + JSON.stringify(result);
   });
 
   return {
     score: pass ? weight : 0,
     max_score: weight,
-    diff: pass ? '' : 'unexpected result found'
+    diff: pass ? '' : diff
   };
 }
 

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -156,5 +156,6 @@ function scoreTest(testCase, apiResults, context) {
 }
 
 module.exports = {
+  scoreUnexpected: scoreUnexpected,
   scoreTest: scoreTest
 };

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -155,4 +155,6 @@ function scoreTest(testCase, apiResults, context) {
   return scores.reduce(helpers.combineScores, helpers.initial_score);
 }
 
-module.exports = scoreTest;
+module.exports = {
+  scoreTest: scoreTest
+};

--- a/test/scoreTest.js
+++ b/test/scoreTest.js
@@ -1,0 +1,33 @@
+var tape = require( 'tape' );
+
+var scoreTest = require( '../lib/scoreTest' );
+
+tape( 'scoreUnexpected basics', function ( test ){
+  test.test('default weight returned when no unexpected properties found', function(t) {
+    var unexpected = {
+      properties: [
+        {
+          name: 'unexpectedName'
+        }
+      ]
+    };
+
+    var results = [
+      {
+        properties: {
+          name: 'a great name'
+        }
+      },
+      {
+        properties: {
+          name: 'another great name'
+        }
+      }
+    ];
+    var result = scoreTest.scoreUnexpected(unexpected, results);
+    t.equal(result.score, 1, 'score is 1 (the default weight)');
+    t.equal(result.max_score, 1, 'max score is 1');
+    t.equal(result.diff, '', 'diff is empty');
+    t.end();
+  });
+});

--- a/test/scoreTest.js
+++ b/test/scoreTest.js
@@ -30,4 +30,33 @@ tape( 'scoreUnexpected basics', function ( test ){
     t.equal(result.diff, '', 'diff is empty');
     t.end();
   });
+
+  test.test('0 score returned when unexpected property found', function(t) {
+    var unexpected = {
+      properties: [
+        {
+          name: 'unexpectedName'
+        }
+      ]
+    };
+
+    var results = [
+      {
+        properties: {
+          name: 'a great name'
+        }
+      },
+      {
+        properties: {
+          name: 'unexpectedName'
+        }
+      }
+    ];
+    var result = scoreTest.scoreUnexpected(unexpected, results);
+    t.equal(result.score, 0, 'score is 0');
+    t.equal(result.max_score, 1, 'max score is 1');
+    t.deepEquals(result.diff,[ 'unexpected result found from {"name":"unexpectedName"}' ],
+                 'the diff says which unexpected result was found');
+    t.end();
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,4 +10,5 @@ require('./eval_test');
 require('./equal_properties');
 require('./sanitiseTestCase');
 require('./scoreProperties');
+require('./scoreTest');
 require('./normalizers');


### PR DESCRIPTION
Instead of simply showing "unexpected result found", show what the value of that unexpected thing is.

![unexpectednew](https://cloud.githubusercontent.com/assets/111716/14928071/a76ab8c6-0e23-11e6-8f4e-d8ddb1bf662a.png)

Fixes #51 
