### PR TITLE
Refactor, document, add some tests

### DIFF
--- a/bin/fuzzy-tester
+++ b/bin/fuzzy-tester
@@ -27,15 +27,15 @@ var analyze_results = require( '../lib/analyze_results' );
   var urls = gather_test_urls(config, testSuites);
 
   // request all urls
-  request_urls(urls, function processResults(results) {
-    // results is a simple object where the keys are urls, and the value is the
+  request_urls(urls, function processResponses(responses) {
+    // responses is a simple object where the keys are urls, and the value is the
     // entire response from fetching that url
     // test cases can have many URLs (in autocomplete mode), and the same url
     // could be used in multiple tests, so the relationship between test cases and
-    // results is complex.
+    // responses is complex.
 
     // evaluate all test suites (perform scoring, generate diffs, etc)
-    var evaled_results = eval_tests(testSuites, results);
+    var evaled_results = eval_tests(testSuites, responses);
 
     // perform any final required analysis (such as calculating stats)
     var analyzed_results = analyze_results(testSuites, evaled_results, config, startTime);

--- a/bin/fuzzy-tester
+++ b/bin/fuzzy-tester
@@ -18,8 +18,22 @@ var analyze_results = require( '../lib/analyze_results' );
   // get configuration options sent via command line parameters
   var config = processArguments.getConfig();
 
-  // steps to be performed after urls have been fetched
-  var callback = function(results) {
+  // find all test suites and test cases that will be run
+  // configuration parameters may filter out some tests (i.e. with -t dev)
+  var testSuites = gather_test_suites(config);
+  // check all test suites for errors and perform any needed cleanup
+  validateTestSuites(testSuites);
+  // collect all urls with parameters that tests require fetched
+  var urls = gather_test_urls(config, testSuites);
+
+  // request all urls
+  request_urls(urls, function processResults(results) {
+    // results is a simple object where the keys are urls, and the value is the
+    // entire response from fetching that url
+    // test cases can have many URLs (in autocomplete mode), and the same url
+    // could be used in multiple tests, so the relationship between test cases and
+    // results is complex.
+
     // evaluate all test suites (perform scoring, generate diffs, etc)
     var evaled_results = eval_tests(testSuites, results);
 
@@ -30,16 +44,6 @@ var analyze_results = require( '../lib/analyze_results' );
     var return_code = config.outputGenerator(evaled_results, config, testSuites);
 
     process.exitCode = return_code;
-  };
+  });
 
-  // find all test suites and test cases that will be run
-  // configuration parameters may filter out some tests (i.e. with -t dev)
-  var testSuites = gather_test_suites(config);
-  // check all test suites for errors and perform any needed cleanup
-  validateTestSuites(testSuites);
-  // collect all urls with parameters that tests require fetched
-  var urls = gather_test_urls(config, testSuites);
-
-  // request all urls
-  request_urls(urls, callback);
 })();

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -116,11 +116,11 @@ function composeNormalizer(normalizers) {
 }
 
 /**
- * Given a test-case, the API results for the input it specifies, and a
+ * Given a test-case, the API response for the input it specifies, and a
  * priority-threshold to find the results in, return an object indicating the
  * status of this test (whether it passed, failed, is a placeholder, etc.)
  */
-function evalTest( testCase, apiResults, context ){
+function evalTest( testCase, apiResponse, context ){
   context = _.clone(context, true);
 
   context = makeTestContext( testCase, context );
@@ -135,7 +135,7 @@ function evalTest( testCase, apiResults, context ){
     };
   }
 
-  if ( !isObject(apiResults) || apiResults.length === 0 ) {
+  if ( !isObject(apiResponse) || apiResponse.length === 0 ) {
     return {
       result: 'fail',
       msg: 'no results returned'
@@ -144,9 +144,9 @@ function evalTest( testCase, apiResults, context ){
 
   // normalize expected and actual properties in preparation for scoreTest
   testCase = normalizeExpected(testCase, context.propertyNormalizers);
-  apiResults = normalizeActual(apiResults, context.propertyNormalizers);
+  apiResponse = normalizeActual(apiResponse, context.propertyNormalizers);
 
-  var score = scoreTest.scoreTest(testCase, apiResults, context);
+  var score = scoreTest.scoreTest(testCase, apiResponse, context);
 
   return {
     result: (score.score < score.max_score) ? 'fail' : 'pass',
@@ -181,8 +181,8 @@ function normalizeExpected(testCase, fieldNormalizers) {
   return testCase;
 }
 
-function normalizeActual(apiResults, fieldNormalizers) {
-  return apiResults.map(function(obj) {
+function normalizeActual(apiResponse, fieldNormalizers) {
+  return apiResponse.map(function(obj) {
     Object.keys(obj.properties).
       // find all properties with normalizers
       filter( function(key) {

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -86,9 +86,7 @@ function makeTestContext( testCase, context ) {
       // otherwise just look up the requested normalizer in the set of suppported normalizers
       propertyNormalizers[propertyNormalizer] =
         supportedNormalizers[propertyNormalizers[propertyNormalizer]];
-
     }
-
   }
 
   context.propertyNormalizers = propertyNormalizers;
@@ -178,11 +176,9 @@ function normalizeExpected(testCase, fieldNormalizers) {
       });
 
     return obj;
-
   });
 
   return testCase;
-
 }
 
 function normalizeActual(apiResults, fieldNormalizers) {
@@ -198,9 +194,7 @@ function normalizeActual(apiResults, fieldNormalizers) {
       });
 
     return obj;
-
   });
-
 }
 
 function hasAnArrayOfExpectedProperties(testCase) {

--- a/lib/eval_tests.js
+++ b/lib/eval_tests.js
@@ -2,7 +2,7 @@ var _ = require( 'lodash' );
 var evalTest = require( '../lib/eval_test' );
 var test_suite_helpers = require( '../lib/test_suite_helpers' );
 
-function printRequestErrorMessage(testCase, res) {
+function printRequestErrorMessage(testCase, response) {
   // replacer for console.error of testCase to avoid circular structure
   function replace(key, value) {
     if (key === 'results') {
@@ -10,16 +10,17 @@ function printRequestErrorMessage(testCase, res) {
     }
     return value;
   }
-  console.error( 'Unexpected status code %s.\n'.red, res.statusCode );
+
+  console.error( 'Unexpected status code %s.\n'.red, response.statusCode );
   console.error(
     'Failed for test case:\n%s\n',
     JSON.stringify( testCase, replace, 4 ).replace( /^|\n/g, '\n\t' )
   );
   console.error(
     'Response:\n%s\n',
-    JSON.stringify( res, undefined, 4 ).replace( /^|\n/g, '\n\t' )
+    JSON.stringify( response, undefined, 4 ).replace( /^|\n/g, '\n\t' )
   );
-  console.error( '\nInvestigate manually:\n  curl %s', res.request.uri.href );
+  console.error( '\nInvestigate manually:\n  curl %s', response.request.uri.href );
 }
 
 function createContext(testSuite, locations) {
@@ -32,7 +33,7 @@ function createContext(testSuite, locations) {
   };
 }
 
-function eval_test_suite(testSuite, results) {
+function eval_test_suite(testSuite, responses) {
   var locations = test_suite_helpers.getLocations();
   var context = createContext(testSuite, locations);
 
@@ -44,17 +45,17 @@ function eval_test_suite(testSuite, results) {
     }
 
     return urls.map(function(url) {
-      var res = results[url];
+      var response = responses[url];
       var result;
 
-      if( res.statusCode === 200 ){
-        result = evalTest( testCase, res.body.features, context );
+      if( response.statusCode === 200 ){
+        result = evalTest( testCase, response.body.features, context );
       } else {
-        printRequestErrorMessage(testCase, res);
+        printRequestErrorMessage(testCase, response);
 
         result = {
           result: 'fail',
-          msg: 'Unexpected status code ' + res.statusCode
+          msg: 'Unexpected status code ' + response.statusCode
         };
       }
 
@@ -67,9 +68,9 @@ function eval_test_suite(testSuite, results) {
   });
 }
 
-function eval_tests(testSuites, results) {
+function eval_tests(testSuites, responses) {
   return _.flatten(testSuites.map(function(testSuite) {
-    return eval_test_suite(testSuite, results);
+    return eval_test_suite(testSuite, responses);
   }));
 }
 

--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -27,7 +27,7 @@ function shouldRetryRequest(res) {
 
 function request_urls(urls, callback) {
   var total_length = urls.length;
-  var results = {};
+  var responses = {};
   var agent = new http.Agent({keepAlive: true, maxSockets: 1});
   var intervalId;
   var test_interval = new ExponentialBackoff(1, 5, 1, 20000);
@@ -55,19 +55,19 @@ function request_urls(urls, callback) {
       else if( shouldRetryRequest(res) ){
         urls.push(url);
         retries++;
-        printProgress(Object.keys(results).length, total_length);
+        printProgress(Object.keys(responses).length, total_length);
         test_interval.increaseBackoff();
       }
       else {
-        results[url] = res;
+        responses[url] = res;
         test_interval.decreaseBackoff();
 
-        printProgress(Object.keys(results).length, total_length);
+        printProgress(Object.keys(responses).length, total_length);
       }
 
-      if( Object.keys(results).length === total_length ){
+      if( Object.keys(responses).length === total_length ){
         clearInterval(intervalId);
-        callback( results );
+        callback( responses );
       } else {
         if (delay !== test_interval.getBackoff()) {
           delay = test_interval.getBackoff();

--- a/lib/sanitiseTestCase.js
+++ b/lib/sanitiseTestCase.js
@@ -57,9 +57,7 @@ function normalizeCoordinates(coordinates) {
   return coordinates;
 }
 
-
-function sanitiseTestCase(testCase, locations)
-{
+function sanitiseTestCase(testCase, locations) {
   locations = locations || {};
 
   if (!testCase.expected && !testCase.unexpected) {

--- a/lib/scoreHelpers.js
+++ b/lib/scoreHelpers.js
@@ -76,14 +76,14 @@ function combineScores(total_score, this_score) {
 }
 
 /**
- * Small helper function to determine if a given apiResult is high
- * enough in a set of results to pass a priority threshold.
- * Caveat: the result object must be the exact same javascript object
- * as the one taken from the apiResults, not just another object with
+ * Small helper function to determine if a given responseFeature is high
+ * enough in a set of responseFeatures to pass a priority threshold.
+ * Caveat: the feature object must be the exact same javascript object
+ * as the one taken from the responseFeatures, not just another object with
  * identical properties
  */
-function inPriorityThresh(apiResults, result, priorityThresh) {
-  var index = apiResults.indexOf(result);
+function inPriorityThresh(responseFeatures, responseFeature, priorityThresh) {
+  var index = responseFeatures.indexOf(responseFeature);
   return index !== -1 && index <= priorityThresh - 1;
 }
 

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -136,9 +136,7 @@ function scoreTest(testCase, responseFeatures, context) {
 
   if (testCase.expected) {
     var coordinates = testCase.expected.coordinates || [];
-    scores = scores.concat(testCase.expected.properties.map(function(expected_props) {
-      // find the matching coodinate entry
-      var index = testCase.expected.properties.indexOf(expected_props);
+    scores = scores.concat(testCase.expected.properties.map(function(expected_props, index) {
       var expected = { 'properties':  expected_props, 'coordinates': coordinates[index] };
 
       return scoreOneExpectation(expected, responseFeatures, context);

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -4,15 +4,15 @@ var scoreCoordinates = require( '../lib/scoreCoordinates' );
 var scoreProperties = require( '../lib/scoreProperties' );
 
 /**
- * Calculate the score component for a results object's position in the returned
- * results. If it is later in the results than the threshold, no points.
+ * Calculate the score component for a response feature object's position in the returned
+ * response features. If it is later in the featuress than the threshold, no points.
  * Otherwise, full points.
  */
-function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
-  var index = apiResults.indexOf(result);
+function scorePriorityThresh(priorityThresh, responseFeature, responseFeatures, weight) {
+  var index = responseFeatures.indexOf(responseFeature);
   var diff = '';
   var score = weight;
-  var success = helpers.inPriorityThresh(apiResults, result, priorityThresh);
+  var success = helpers.inPriorityThresh(responseFeatures, responseFeature, priorityThresh);
   if (!success) {
     score = 0;
     diff = 'priorityThresh is ' + priorityThresh + ' but found at position ' + (index + 1);
@@ -29,21 +29,21 @@ function scorePriorityThresh(priorityThresh, result, apiResults, weight) {
 
 /**
  * Calculate the score component for the absence of unexpected properties in
- * API results. Full points are awarded if all of the unexpected properties
- * are completely absent from all API results. Otherwise no points.
+ * response features. Full points are awarded if all of the unexpected properties
+ * are completely absent from all API response features. Otherwise no points.
  */
-function scoreUnexpected(unexpected, apiResults, weight) {
+function scoreUnexpected(unexpected, responseFeatures, weight) {
   weight = weight || 1;
-  // unexpected result should be absent from every returned result
-  var unexpectedResults = unexpected.properties.filter(function(property) {
-    return apiResults.some(function(result) {
-      return equalProperties(property, result.properties);
+  // unexpected properties should be absent from every returned response feature
+  var unexpectedProperties = unexpected.properties.filter(function(property) {
+    return responseFeatures.some(function(responseFeature) {
+      return equalProperties(property, responseFeature.properties);
     });
   });
-  var pass = unexpectedResults.length === 0;
+  var pass = unexpectedProperties.length === 0;
 
-  var diff = unexpectedResults.map(function(result) {
-    return 'unexpected result found from ' + JSON.stringify(result);
+  var diff = unexpectedProperties.map(function(property) {
+    return 'unexpected property found from ' + JSON.stringify(property);
   });
 
   return {
@@ -54,24 +54,24 @@ function scoreUnexpected(unexpected, apiResults, weight) {
 }
 
 /**
- * Score one result from the set of api results by combining the score
- * for its properties, score for its coordinates and whether or not
- * it satisfies the priorityThresh
+ * Score one feature from the set of response features by combining the score
+ * for its properties, score for its coordinates and whether or not it
+ * satisfies the priorityThresh
  */
-function scoreOneResult(expected, apiResult, apiResults, context) {
+function scoreOneFeature(expected, responseFeature, responseFeatures, context) {
   var subscores = [
-    scoreProperties(expected.properties, apiResult.properties, context.weights.properties),
+    scoreProperties(expected.properties, responseFeature.properties, context.weights.properties),
   ];
 
   if (expected.coordinates) {
-    subscores = subscores.concat(scoreCoordinates(expected.coordinates, apiResult,
+    subscores = subscores.concat(scoreCoordinates(expected.coordinates, responseFeature,
       context.distanceThresh, context.weights.coordinates));
   }
 
   // only score priorityThresh when properties score match completely
   if (subscores[0].score === subscores[0].max_score) {
     subscores = subscores.concat(
-      scorePriorityThresh(context.priorityThresh, apiResult, apiResults, context.weights.priorityThresh)
+      scorePriorityThresh(context.priorityThresh, responseFeature, responseFeatures, context.weights.priorityThresh)
     );
   }
 
@@ -79,19 +79,19 @@ function scoreOneResult(expected, apiResult, apiResults, context) {
 }
 
 /**
- * Score one result from the set of api results by combining the score
+ * Score one feature from the set of response features by combining the score
  * for its coordinates and whether or not it satisfies the priorityThresh
  */
-function scoreOneCoordinateResult(expected_coords, apiResult, apiResults, context) {
+function scoreOneCoordinateFeature(expected_coords, responseFeature, responseFeatures, context) {
   var subscores = [
-    scoreCoordinates(expected_coords, apiResult,
+    scoreCoordinates(expected_coords, responseFeature,
       context.distanceThresh, context.weights.coordinates)
   ];
 
   // only score priorityThresh when coordinates score matches
   if (subscores[0].score === subscores[0].max_score) {
     subscores = subscores.concat(
-      scorePriorityThresh(context.priorityThresh, apiResult, apiResults, context.weights.priorityThresh)
+      scorePriorityThresh(context.priorityThresh, responseFeature, responseFeatures, context.weights.priorityThresh)
     );
   }
 
@@ -107,11 +107,11 @@ function sortScores(score_a, score_b) {
 
 /**
  * Score one (out of potentially many) expectations in a test suite by finding
- * the highest score of any api result when scored against this expectation.
+ * the highest score of any response feature when scored against this expectation.
  */
-function scoreOneExpectation(expected, apiResults, context) {
-  return apiResults.map(function(result) {
-    var score = scoreOneResult(expected, result, apiResults, context);
+function scoreOneExpectation(expected, responseFeatures, context) {
+  return responseFeatures.map(function(responseFeature) {
+    var score = scoreOneFeature(expected, responseFeature, responseFeatures, context);
     return score;
   }).sort(sortScores)[0];
 }
@@ -120,9 +120,9 @@ function scoreOneExpectation(expected, apiResults, context) {
  * Score one (out of potentially many) coordinate expectation
  * independently of properties
  */
-function scoreOneCoordinateExpectation(expected_coords, apiResults, context) {
-  return apiResults.map(function(result) {
-    var score = scoreOneCoordinateResult(expected_coords, result, apiResults, context);
+function scoreOneCoordinateExpectation(expected_coords, responseFeatures, context) {
+  return responseFeatures.map(function(responseFeature) {
+    var score = scoreOneCoordinateFeature(expected_coords, responseFeature, responseFeatures, context);
     return score;
   }).sort(sortScores)[0];
 }
@@ -131,7 +131,7 @@ function scoreOneCoordinateExpectation(expected_coords, apiResults, context) {
  * Score an entire test by combining the score for each expectation,
  * and the score for any unexpected properties.
  */
-function scoreTest(testCase, apiResults, context) {
+function scoreTest(testCase, responseFeatures, context) {
   var scores = [];
 
   if (testCase.expected) {
@@ -141,19 +141,19 @@ function scoreTest(testCase, apiResults, context) {
       var index = testCase.expected.properties.indexOf(expected_props);
       var expected = { 'properties':  expected_props, 'coordinates': coordinates[index] };
 
-      return scoreOneExpectation(expected, apiResults, context);
+      return scoreOneExpectation(expected, responseFeatures, context);
     }));
 
     // If there are no 'text' properties, run plain coordinate matching
     if (testCase.expected.properties.length===0 && testCase.expected.coordinates) {
       scores = scores.concat(testCase.expected.coordinates.map(function(expected_coords) {
-        return scoreOneCoordinateExpectation(expected_coords, apiResults, context);
+        return scoreOneCoordinateExpectation(expected_coords, responseFeatures, context);
       }));
     }
   }
 
   if (testCase.unexpected) {
-    scores = scores.concat(scoreUnexpected(testCase.unexpected, apiResults, context.weights.unexpected));
+    scores = scores.concat(scoreUnexpected(testCase.unexpected, responseFeatures, context.weights.unexpected));
   }
 
   return scores.reduce(helpers.combineScores, helpers.initial_score);

--- a/lib/validate_test_suites.js
+++ b/lib/validate_test_suites.js
@@ -25,20 +25,20 @@ function validateTestSuite(testSuite) {
       var countError = 'Coordinates must have 2 values for lon and lat. Exiting.';
 
       if (coordinateList.constructor === Array ) {
-	if (Array.isArray(coordinateList[0])) { // multiple expected coordinates
-	  coordinateList.forEach( function ( coords ){
+        if (Array.isArray(coordinateList[0])) { // multiple expected coordinates
+          coordinateList.forEach( function ( coords ){
             if( coords.constructor !== Array ){ // do not allow mixed types at this point
               throw 'Unexpected: coordinates MUST be arrays! Exiting.';
             }
-	    if( coords.length !== 2 ){
+            if( coords.length !== 2 ){
               throw countError;
             }
-	  });
-	} else { // single lon, lat value pair
-	  if( coordinateList.length !== 2 ){
+          });
+        } else { // single lon, lat value pair
+          if( coordinateList.length !== 2 ){
             throw countError;
           }
-	}
+        }
       }
     }
 

--- a/test/scoreTest.js
+++ b/test/scoreTest.js
@@ -59,4 +59,85 @@ tape( 'scoreUnexpected basics', function ( test ){
                  'the diff says which unexpected feature was found');
     t.end();
   });
+
+  test.test('correct score returned when result not within specified distance of coordinates', function(t) {
+    var context = {
+      distanceThresh: 1000,
+      priorityThresh: 1,
+      weights: {
+        coordinates: 1,
+        priorityThresh: 1
+      }
+    };
+    var testCase = {
+      expected: {
+        properties: [
+          {
+            name: 'test'
+          }
+        ],
+        coordinates: [
+          [ 1.0, 1.0]
+        ]
+      }
+    };
+
+    var features = [
+      {
+        properties: {
+          name: 'test',
+          locality: 'place'
+        },
+        geometry: {
+          coordinates: [ 50.0, 50.0]
+        }
+      }
+    ];
+
+    var result = scoreTest.scoreTest(testCase, features, context);
+    t.equal(result.score, 2, 'score is 2');
+    t.equal(result.max_score, 3, 'max score is 3');
+    t.deepEquals(result.diff,[ 'test,place is not close enough, distance=7140266 m' ],
+                 'the diff shows the distance from the expected coordinate');
+    t.end();
+  });
+
+  test.test('correct score when result not within specified distance, and there are no properties', function(t) {
+    var context = {
+      distanceThresh: 1000,
+      priorityThresh: 1,
+      weights: {
+        coordinates: 1,
+        priorityThresh: 1
+      }
+    };
+    var testCase = {
+      expected: {
+        properties: [
+        ],
+        coordinates: [
+          [ 1.0, 1.0]
+        ]
+      }
+    };
+
+    var features = [
+      {
+        properties: {
+          name: 'test',
+          locality: 'place'
+        },
+        geometry: {
+          coordinates: [ 50.0, 50.0]
+        }
+      }
+    ];
+
+    var result = scoreTest.scoreTest(testCase, features, context);
+    t.equal(result.score, 0, 'score is 0');
+    t.equal(result.max_score, 1, 'max score is 1');
+    t.deepEquals(result.diff,[ 'test,place is not close enough, distance=7140266 m' ],
+                 'the diff shows the distance from the expected coordinate');
+    t.end();
+  });
 });

--- a/test/scoreTest.js
+++ b/test/scoreTest.js
@@ -12,7 +12,7 @@ tape( 'scoreUnexpected basics', function ( test ){
       ]
     };
 
-    var results = [
+    var features = [
       {
         properties: {
           name: 'a great name'
@@ -24,7 +24,7 @@ tape( 'scoreUnexpected basics', function ( test ){
         }
       }
     ];
-    var result = scoreTest.scoreUnexpected(unexpected, results);
+    var result = scoreTest.scoreUnexpected(unexpected, features);
     t.equal(result.score, 1, 'score is 1 (the default weight)');
     t.equal(result.max_score, 1, 'max score is 1');
     t.equal(result.diff, '', 'diff is empty');
@@ -40,7 +40,7 @@ tape( 'scoreUnexpected basics', function ( test ){
       ]
     };
 
-    var results = [
+    var features = [
       {
         properties: {
           name: 'a great name'
@@ -52,11 +52,11 @@ tape( 'scoreUnexpected basics', function ( test ){
         }
       }
     ];
-    var result = scoreTest.scoreUnexpected(unexpected, results);
+    var result = scoreTest.scoreUnexpected(unexpected, features);
     t.equal(result.score, 0, 'score is 0');
     t.equal(result.max_score, 1, 'max score is 1');
-    t.deepEquals(result.diff,[ 'unexpected result found from {"name":"unexpectedName"}' ],
-                 'the diff says which unexpected result was found');
+    t.deepEquals(result.diff,[ 'unexpected property found from {"name":"unexpectedName"}' ],
+                 'the diff says which unexpected feature was found');
     t.end();
   });
 });


### PR DESCRIPTION
While doing the work to fix #30 I had to dive into some code to get context and couldn't help but refactor and add some tests along the way. Details are in the individual commit messages, but this PR does some rearranging for readability, add some more descriptions, vastly cleans up variable name usage ([four different concepts called "results" now have separate names](https://github.com/pelias/fuzzy-tester/commit/19c599eececf44e542d07360f35420128fd4c6e9)), and of course fixes some whitespace.
