### PR TITLE
Update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 0.12
   - 4
-  - 5
   - 6
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 matrix:
   fast_finish: true
   allow_failures:
-    - node_js: 6
 env:
   global:
     - CXX=g++-4.8


### PR DESCRIPTION
- Remove Node.js v5
- Require tests to pass on Node.js v6

Fixes https://github.com/pelias/pelias/issues/401
Connects https://github.com/pelias/pelias/issues/334
