### PR TITLE
Move results summary to top of email

### DIFF
--- a/output_generators/email_static/email.html
+++ b/output_generators/email_static/email.html
@@ -59,15 +59,6 @@
 </style>
 Tests for: <b>{{config.endpoint.url}} ( {{ config.endpoint.name }} )</b>
 
-{{#each testSuites}}
-	<h2>{{name}}</h2>
-	<ul>
-		{{#each tests}}
-			<li class="{{result.result}}-{{status}}">{{testCase this}}</li>
-		{{/each}}
-	</ul>
-{{/each}}
-
 <div>
 	pass: <span style="color: green;">{{suiteResults.stats.pass}}</span><br>
 	improvements: <span style="color: green;">{{suiteResults.stats.improvement}}</span><br>
@@ -82,3 +73,12 @@ Tests for: <b>{{config.endpoint.url}} ( {{ config.endpoint.name }} )</b>
 		<p class="success">No regressions detected. All clear.</p>
 	{{/if}}
 </div>
+
+{{#each testSuites}}
+	<h2>{{name}}</h2>
+	<ul>
+		{{#each tests}}
+			<li class="{{result.result}}-{{status}}">{{testCase this}}</li>
+		{{/each}}
+	</ul>
+{{/each}}


### PR DESCRIPTION
The layout of the emails mirrored the command line output, where it
makes sense for the results to be printed last. However, for an email,
you want the summary first!