### PR TITLE
feat: set up semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,12 @@ addons:
 cache:
   directories:
     - node_modules
+notifications:
+  email: false
 before_script:
   - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pelias-fuzzy-tester",
-  "version": "0.7.0",
+  "version": "0.0.0-development",
   "description": "A testing suite by Mapzen with fuzzy testing ability",
   "keywords": [
     "tests",
@@ -15,7 +15,8 @@
     "units": "node test/test | tap-dot",
     "test": "npm run units",
     "lint": "jshint .",
-    "validate": "npm ls"
+    "validate": "npm ls",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "bin": {
     "fuzzy-tester": "./bin/fuzzy-tester"
@@ -46,7 +47,8 @@
     "tap-dot": "^1.0.0",
     "through2": "^2.0.0",
     "csv-parse": ">=1.0.0",
-    "proj4": "^2.3.12"
+    "proj4": "^2.3.12",
+    "semantic-release": "^6.3.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We previously didn't use semantic-release for this repo, because we had
multiple version branches maintained simultaneously, but now only the
latest matters.