### PR TITLE
Add quiet output flag to skip passing tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "node": true,
   "curly": true,
   "eqeqeq": true,
+  "esversion": 6,
   "freeze": true,
   "immed": true,
   "indent": 2,
@@ -14,8 +15,8 @@
   "plusplus": false,
   "quotmark": "single",
   "undef": true,
-  "unused": true,
+  "unused": false,
   "maxparams": 4,
   "maxdepth": 4,
-  "maxlen": 120
+  "maxlen": 140
 }

--- a/lib/processArguments.js
+++ b/lib/processArguments.js
@@ -36,7 +36,9 @@ function setUpCommander() {
   );
 
   var filesHelp = 'The specific test-suite files to execute. ' +
-  'If not specified, all files in ./test_cases will be run.';
+    'If not specified, all files in ./test_cases will be run.';
+
+  var noPassingHelp = 'If specified, details of all passing tests will be omitted from results';
 
   commander
   .usage( '[flags] [file(s)]' )
@@ -53,6 +55,11 @@ function setUpCommander() {
   .option(
     '-t, --test-type <testType>',
     util.format( 'The type of tests to run, as specified in test-cases\' `type` property.' )
+  )
+  .option(
+    '-q, --quiet',
+    noPassingHelp,
+    false
   )
   .option( 'files', filesHelp )
   .parse( process.argv );
@@ -109,7 +116,8 @@ function getConfig() {
     outputGenerator: outputGenerator,
     testType: commander.testType,
     testSuites: testSuites,
-    autocomplete: commander.output === 'autocomplete'
+    autocomplete: commander.output === 'autocomplete',
+    quiet: commander.quiet
   };
 
   return config;

--- a/output_generators/csv.js
+++ b/output_generators/csv.js
@@ -1,0 +1,66 @@
+/**
+ * @file A terminal/json-file output generator for test-suites results.
+ */
+
+'use strict';
+
+var util = require( 'util' );
+var fs = require('fs-extra');
+var terminal = require('./terminal');
+var haversine = require( 'haversine' ); // distance measure for angle coords
+
+// replacer for stringifying testCase to avoid circular structure
+function replace(key, value) {
+  if (key === 'results' || key === 'result') {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Format and print a test result to csv file.
+ */
+function saveTestResult(testCase) {
+
+  var line = `${testCase.id}, "${testCase.in.text}",`;
+  line += `${testCase.expected.coordinates[0][0] }, ${testCase.expected.coordinates[0][1] },`;
+
+  if (testCase.result.response.body.features.length > 0) {
+    line += `"${testCase.result.response.body.features[0].properties.label}",`;
+    line += `${testCase.result.response.body.features[0].geometry.coordinates[0]},`;
+    line += `${testCase.result.response.body.features[0].geometry.coordinates[1]},`;
+
+    const p1 = {
+      longitude: testCase.expected.coordinates[0][0],
+      latitude: testCase.expected.coordinates[0][1]
+    };
+    const p2 = {
+      longitude: testCase.result.response.body.features[0].geometry.coordinates[0],
+      latitude: testCase.result.response.body.features[0].geometry.coordinates[1]
+    };
+    line += Math.floor(haversine(p1, p2)*1000); // to metres
+  }
+    
+  return line + '\n';
+}
+
+/**
+ * Format and print all of the results from any number of test-suites.
+ */
+function prettyPrintSuiteResults( suiteResults, config, testSuites ) {
+
+  let output = 'count,address,exp_lon,exp_lat,act_address,act_lon,act_lat,dist\n';
+
+  testSuites.forEach(function(suite) {
+    suite.tests.forEach(function(testCase) {
+      testCase.result = testCase.results[testCase.full_url];
+      output += saveTestResult( testCase );
+    });
+  });
+
+  fs.writeFileSync('./csv_results.csv', output);
+  
+  return terminal( suiteResults, config, testSuites );
+}
+
+module.exports = prettyPrintSuiteResults;

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -14,7 +14,7 @@ var percentageForDisplay = require('../lib/percentageForDisplay');
 /**
  * Format and print a test result to the terminal.
  */
-function prettyPrintResult( result ){
+function prettyPrintResult( result, quiet ){
   var id = result.testCase.id;
   delete result.testCase.in.api_key; // don't display API key
 
@@ -32,7 +32,9 @@ function prettyPrintResult( result ){
   var status = (result.progress === undefined) ? '' : result.progress.inverse + ' ';
   switch( result.result ){
     case 'pass':
-      console.log( util.format( '  ✔ %s[%s] "%s"', status, id, testDescription ).green );
+      if (!quiet) {
+        console.log(util.format('  ✔ %s[%s] "%s"', status, id, testDescription).green);
+      }
       break;
 
     case 'fail':
@@ -63,7 +65,7 @@ function prettyPrintSuiteResults( suiteResults, config, testSuites ){
     console.log();
     console.log(testSuite.name.blue);
     testSuite.tests.forEach( function(testCase) {
-      prettyPrintResult( testCase.results[testCase.full_url] );
+      prettyPrintResult( testCase.results[testCase.full_url], config.quiet );
     });
   });
 

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -14,8 +14,8 @@ var percentageForDisplay = require('../lib/percentageForDisplay');
 /**
  * Format and print a test result to the terminal.
  */
-function prettyPrintResult( result, quiet ){
-  var id = result.testCase.id;
+function prettyPrintResult( result, testSuite, quiet ){
+  var id = quiet ? `[${testSuite}][${result.testCase.id}]` : `[${result.testCase.id}]`;
   delete result.testCase.in.api_key; // don't display API key
 
   var input = JSON.stringify(result.testCase.in);
@@ -33,19 +33,19 @@ function prettyPrintResult( result, quiet ){
   switch( result.result ){
     case 'pass':
       if (!quiet) {
-        console.log(util.format('  ✔ %s[%s] "%s"', status, id, testDescription).green);
+        console.log(util.format('  ✔ %s %s "%s"', status, id, testDescription).green);
       }
       break;
 
     case 'fail':
       var color = (result.progress === 'regression') ? 'red' : 'yellow';
       console.log(
-        util.format( '  ✘ %s[%s] "%s": %s', status, id, testDescription, result.msg )[ color ]
+        util.format( '  ✘ %s %s "%s": %s', status, id, testDescription, result.msg )[ color ]
       );
       break;
 
     case 'placeholder':
-      console.log( util.format( '  ! [%s] "%s": %s', id, testDescription, result.msg ).cyan );
+      console.log( util.format( '  ! %s "%s": %s', id, testDescription, result.msg ).cyan );
       break;
 
     default:
@@ -61,11 +61,13 @@ function prettyPrintResult( result, quiet ){
 function prettyPrintSuiteResults( suiteResults, config, testSuites ){
   console.log( 'Tests for:', config.endpoint.url.blue + ' (' + config.endpoint.name.blue + ')' );
 
-  testSuites.forEach( function(testSuite) {
-    console.log();
-    console.log(testSuite.name.blue);
+  testSuites.forEach(function (testSuite) {
+    if (!config.quiet) {
+      console.log();
+      console.log(testSuite.name.blue);
+    }
     testSuite.tests.forEach( function(testCase) {
-      prettyPrintResult( testCase.results[testCase.full_url], config.quiet );
+      prettyPrintResult( testCase.results[testCase.full_url], testSuite.name, config.quiet );
     });
   });
 


### PR DESCRIPTION
Fixes #94 

the new flag is `--quiet` or `-q` which will skip details of passing tests