### PR TITLE
Revert to nodemailer 2.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "is-object": "^1.0.1",
     "juice": "^4.0.0",
     "lodash": "^4.5.1",
-    "nodemailer": "^4.0.1",
+    "nodemailer": "^2.7.2",
     "nodemailer-ses-transport": "1.5.1",
     "pelias-config": "2.9.0",
     "request": "^2.55.0",


### PR DESCRIPTION
Versions 3 and above require Node.js 6, and don't work on Node 4

Fixing https://github.com/pelias/fuzzy-tester/issues/59 would help catch this sort of thing, but actually doing it might be pretty hard.