### PR TITLE
Always use red for regression count color

### DIFF
--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -93,11 +93,10 @@ function prettyPrintSuiteResults( suiteResults, config, testSuites ){
   console.log( 'Placeholders: ' + suiteResults.stats.placeholder.toString().cyan );
 
   var numRegressions = suiteResults.stats.regression;
-  var regressionsColor = ( numRegressions > 0 ) ? 'red' : 'yellow';
   var total = suiteResults.stats.pass +  suiteResults.stats.fail + suiteResults.stats.regression;
   var pass = total - numRegressions;
 
-  console.log( 'Regressions: ' + numRegressions.toString()[ regressionsColor ] );
+  console.log( 'Regressions: ' + numRegressions.toString().red);
   console.log( 'Took %sms', suiteResults.stats.timeTaken );
   console.log( 'Test success rate %s%%', percentageForDisplay(total,pass));
 


### PR DESCRIPTION
We currently display the regression count in yellow if there are zero
regressions, and red if there are regressions.

However, in general regressions are colored red (in test output, for
example), known failures yellow, and passes/improvements green. Keeping
this consistency feels a little more clear, so change the regression
color to always be red.

## Before
![image](https://user-images.githubusercontent.com/111716/31024856-5ef40c68-a50e-11e7-8c3c-3e0bb6598fb2.png)

## After

![image](https://user-images.githubusercontent.com/111716/31024870-69517736-a50e-11e7-950b-1a78bee193b8.png)