### PR TITLE
Add user-agent to request header

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -41,6 +41,7 @@ function request_urls(urls, callback) {
     var url = urls.pop();
 
     var requestOpts = {
+      headers: {'user-agent': 'pelias-fuzzy-tester'},
       url: url,
       json: true,
       agent: agent,


### PR DESCRIPTION
As for now fuzzy-tester doesn't send any `user-agent`, it will be good to have one to determine where the requests come from =)

Thanks