### PR TITLE
[fix] allow https endpoints

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -1,4 +1,5 @@
 var http = require('http');
+var https = require('https');
 var request = require('request');
 
 var ExponentialBackoff = require( '../lib/ExponentialBackoff');
@@ -28,7 +29,8 @@ function shouldRetryRequest(res) {
 function request_urls(urls, callback) {
   var total_length = urls.length;
   var responses = {};
-  var agent = new http.Agent({keepAlive: true, maxSockets: 1});
+  var httpAgent = new http.Agent({keepAlive: true, maxSockets: 1});
+  var httpsAgent = new https.Agent({keepAlive: true, maxSockets: 1});
   var intervalId;
   var test_interval = new ExponentialBackoff(1, 5, 1, 20000);
   var delay = test_interval.getBackoff();
@@ -39,6 +41,8 @@ function request_urls(urls, callback) {
     }
 
     var url = urls.pop();
+
+    const agent = (url.startsWith('https:')) ? httpsAgent : httpAgent;
 
     var requestOpts = {
       headers: {'user-agent': 'pelias-fuzzy-tester'},


### PR DESCRIPTION
I tried to run the acceptance tests on a server which only accepts https connections. It fails because fuzzy-tester uses an http only agent to connect.

To correct this, I added another agent which is used when an url starts with "https:". I tried it with the acceptance test module and it works.