### PR TITLE
feat(normalizers): Add `trim` normalizer

### DIFF
--- a/lib/normalizers.js
+++ b/lib/normalizers.js
@@ -35,6 +35,14 @@ module.exports.toUpperCase = function(val) {
 
 };
 
+module.exports.trim = function(val) {
+  if (!_.isString(val)) {
+    return val;
+  }
+
+  return val.trim();
+};
+
 module.exports.abbreviateDirectionals = function(val) {
   if (!_.isString(val)) {
     return val;

--- a/test/normalizers.js
+++ b/test/normalizers.js
@@ -71,6 +71,13 @@ tape( 'toUpperCase should return string input uppercased', function(test) {
 
 });
 
+tape( 'trim returns string without leading and trailing whitespace', function(test) {
+  var input = ' abc ';
+
+  test.equal(normalizers.trim(input), 'abc');
+  test.end();
+});
+
 tape( 'non-string input to abbreviateDirectionals should return input value unmodified', function(test) {
   var input = { 'foo': { 'bar': '!@#$'}, 'baz': 'AB*()CD'};
 


### PR DESCRIPTION
This allows removing leading and trailing whitespace from result properties.