### PR TITLE
fix(terminal): Restore expectation count output

### DIFF
--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -22,14 +22,15 @@ function prettyPrintTestCase( testCase, quiet ){
 
   var input = JSON.stringify(result.testCase.in);
   var expectationCount;
-  var expectationString = (expectationCount > 1) ? ' (' + expectationCount + ' expectations)' : '';
-  var testDescription = input + expectationString;
 
   if (result.testCase.expected && result.testCase.expected.properties) {
     expectationCount = result.testCase.expected.properties.length;
   } else {
     expectationCount = 0;
   }
+
+  var expectationString = (expectationCount > 1) ? ' (' + expectationCount + ' expectations)' : '';
+  var testDescription = input + expectationString;
 
   var status = (result.progress === undefined) ? '' : result.progress.inverse + ' ';
   switch( result.result ){


### PR DESCRIPTION
We have long had the ability to denote which tests have multiple expectations, but an error in the code was preventing it from ever being used.