### PR TITLE
fix(fs): Avoid deprecation errors

### DIFF
--- a/test/apiKey.js
+++ b/test/apiKey.js
@@ -19,7 +19,7 @@ tape( 'api_key not found in config', function ( test ){
   delete process.env.PELIAS_CONFIG;
 
   // delete temp file
-  fs.unlink( '/tmp/pelias_temp.json' );
+  fs.unlinkSync( '/tmp/pelias_temp.json' );
 
   test.end();
 });
@@ -41,7 +41,7 @@ tape( 'stage api_key imported from pelias config', function ( test ){
   delete process.env.PELIAS_CONFIG;
 
   // delete temp file
-  fs.unlink( '/tmp/pelias_temp2.json' );
+  fs.unlinkSync( '/tmp/pelias_temp2.json' );
 
   test.end();
 });
@@ -63,7 +63,7 @@ tape( 'avoid matching partial urls', function ( test ){
   delete process.env.PELIAS_CONFIG;
 
   // delete temp file
-  fs.unlink( '/tmp/pelias_temp3.json' );
+  fs.unlinkSync( '/tmp/pelias_temp3.json' );
 
   test.end();
 });


### PR DESCRIPTION
Node.js no longer allows calling functions without a callback, which is good: it exposes cases where nasty errors are possible.

We were not supplying callbacks in some cases, which are now replaced with `Sync` calls.