### PR TITLE
feat(output): Print request URLs instead of JSON

### DIFF
--- a/lib/validate_test_suites.js
+++ b/lib/validate_test_suites.js
@@ -2,6 +2,10 @@ var util = require( 'util' );
 
 var validTestStatuses = [ 'pass', 'fail', undefined ];
 
+function setEndpoint(testCase, testSuite) {
+  testCase.endpoint = testCase.endpoint || testSuite.endpoint || 'search';
+}
+
 function validateTestSuite(testSuite) {
   return testSuite.tests.map( function ( testCase ){
     if( validTestStatuses.indexOf( testCase.status ) === -1 ){
@@ -10,6 +14,9 @@ function validateTestSuite(testSuite) {
         testCase.status, JSON.stringify( validTestStatuses )
       );
     }
+
+    // ensure endpoint is set for later use
+    setEndpoint(testCase, testSuite);
 
     if( 'unexpected' in testCase ){
       testCase.unexpected.properties.forEach( function ( props ){

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -8,9 +8,37 @@
 require( 'colors' );
 
 var util = require( 'util' );
+const url = require('url');
 
 var percentageForDisplay = require('../lib/percentageForDisplay');
 var testSuiteHelpers = require('../lib/test_suite_helpers');
+
+function inputToUrl(testCase) {
+  const path = `/v1/${testCase.endpoint}`;
+
+  const paramStrings = [];
+
+  const priorityParams = ['point.lat', 'point.lon', 'text'];
+
+  Object.keys(testCase.in).forEach(function(key) {
+    // skip keys already in the priority list
+    if (priorityParams.includes(key)) {
+      return;
+    } else {
+      paramStrings.push(`${key}=${testCase.in[key]}`);
+    }
+  });
+
+  // ensure priority params are last
+  priorityParams.forEach(function (priorityParam) {
+    if (testCase.in[priorityParam]) {
+      paramStrings.push(`${priorityParam}=${testCase.in[priorityParam]}`);
+    }
+  });
+
+  return `${path}?${paramStrings.join('&')}`;
+}
+
 
 /**
  * Format and print a test result to the terminal.
@@ -20,7 +48,8 @@ function prettyPrintTestCase( testCase, quiet ){
   var id = result.testCase.id;
   delete result.testCase.in.api_key; // don't display API key
 
-  var input = JSON.stringify(result.testCase.in);
+  const query = inputToUrl(testCase);
+
   var expectationCount;
 
   if (result.testCase.expected && result.testCase.expected.properties) {
@@ -30,7 +59,7 @@ function prettyPrintTestCase( testCase, quiet ){
   }
 
   var expectationString = (expectationCount > 1) ? ' (' + expectationCount + ' expectations)' : '';
-  var testDescription = input + expectationString;
+  var testDescription = query + expectationString;
 
   var status = (result.progress === undefined) ? '' : result.progress.inverse + ' ';
   switch( result.result ){


### PR DESCRIPTION
Changes test case output to print a URL instead of a JSON object.

This makes it much easier to copy and paste the output of the fuzzy-tester and examine the results in a browser.
<img width="732" alt="Screen Shot 2019-05-14 at 3 35 31 PM" src="https://user-images.githubusercontent.com/111716/57726822-f4a4fc00-765d-11e9-8309-f8a6793386ae.png">

I'd like to make a few more improvements here:
- ensure the `text` parameter is always last, to work around the requirements of the compare app
- avoid encoding special characters in the output. Most browsers can handle this and it makes parsing the URL harder for humans

Fixes https://github.com/pelias/fuzzy-tester/issues/58
Connects https://github.com/pelias/fuzzy-tester/issues/113