### PR TITLE
Display improvements in quiet mode

### DIFF
--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -64,7 +64,7 @@ function prettyPrintTestCase( testCase, quiet ){
   var status = (result.progress === undefined) ? '' : result.progress.inverse + ' ';
   switch( result.result ){
     case 'pass':
-      if (!quiet) {
+      if (!quiet || result.progress === 'improvement') {
         console.log(util.format('  ✔ %s[%s] "%s"', status, id, testDescription).green);
       }
       break;


### PR DESCRIPTION
This fixes a long-standing bug from all the way back in https://github.com/pelias/fuzzy-tester/pull/96 where improvements are not shown in quiet mode, but the title of test suites where there was an improvement _is_ shown.

The idea of quiet mode is to _only_ show notable output, rather than all output, so showing improvements fits with that goal.

### Before
![Screenshot_2020-04-24_10-02-59](https://user-images.githubusercontent.com/111716/80238187-d50aa780-8612-11ea-9d30-a79fa8a8f1b7.png)

### After
![Screenshot_2020-04-24_10-03-11](https://user-images.githubusercontent.com/111716/80238228-e5228700-8612-11ea-9f22-9765ebfd8da9.png)

