### PR TITLE
fix: Set a default `priorityThresh`

### DIFF
--- a/lib/eval_tests.js
+++ b/lib/eval_tests.js
@@ -25,7 +25,7 @@ function printRequestErrorMessage(testCase, response) {
 
 function createContext(testSuite, locations) {
   return {
-    priorityThresh: testSuite.priorityThresh,
+    priorityThresh: testSuite.priorityThresh || 10,
     distanceThresh: testSuite.distanceThresh,
     locations: locations,
     weights: testSuite.weights,


### PR DESCRIPTION
If not `priorityThresh` was set for an individual test case _or_ its
test suite, the `priorityThresh` value was set to undefined.