### PR TITLE
fix: Handle case where no tests are present

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -38,7 +38,8 @@ function request_urls(config, urls, callback) {
 
   var getOneUrl = function (){
     if( urls.length === 0 ){
-      return;
+      clearInterval(intervalId);
+      return callback([]);
     }
 
     var url = urls.pop();

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -102,6 +102,11 @@ function shouldDisplayTestSuite(testSuite) {
  * Format and print all of the results from any number of test-suites.
  */
 function prettyPrintSuiteResults( suiteResults, config, testSuites ){
+  if (testSuites.length === 0) {
+    console.log('No tests found. Place test definitions in the `test_cases` directory');
+    return 0;
+  }
+
   console.log( 'Tests for:', config.endpoint.url.blue + ' (' + config.endpoint.name.blue + ')' );
 
   testSuites.forEach( function(testSuite) {


### PR DESCRIPTION
Fixes https://github.com/pelias/fuzzy-tester/issues/175

A simple message is printed and the test runner now exits immediately.