### PR TITLE
fix: Handle both no tests existing, and no remaining tests to call

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -37,12 +37,21 @@ function request_urls(config, urls, callback) {
   var delay = test_interval.getBackoff();
 
   var getOneUrl = function (){
-    if( urls.length === 0 ){
+    // check if all responses have been recieved and call the next step in
+    // processing via the `callback` function
+    if( Object.keys(responses).length === total_length ){
       clearInterval(intervalId);
-      return callback([]);
+      return callback( responses );
     }
 
     var url = urls.pop();
+
+    // if there are no more URLs to send requests for, we might
+    // be waiting for some to finish, so just return and the next call to
+    // this function from the ExponentialBackoff manager will try again
+    if (!url) {
+      return;
+    }
 
     const agent = (url.startsWith('https:')) ? httpsAgent : httpAgent;
 


### PR DESCRIPTION
The loop which handles sending off HTTP requests for test cases can have nothing to do under two distinct conditions:

- there are no tests at all
- all test cases have HTTP requests in flight

https://github.com/pelias/fuzzy-tester/pull/190 handled only the first of these, but broke on the second case, causing most test runs to fail.

This adds support for both cases so that graceful handling of empty test directories works, but so does actually running a test suite.