### PR TITLE
feat: Default expected test case status to pass

### DIFF
--- a/lib/validate_test_suites.js
+++ b/lib/validate_test_suites.js
@@ -15,6 +15,11 @@ function validateTestSuite(testSuite) {
       );
     }
 
+    // default test case status to pass when unset
+    if (testCase.status === undefined) {
+      testCase.status = 'pass';
+    }
+
     // ensure endpoint is set for later use
     setEndpoint(testCase, testSuite);
 


### PR DESCRIPTION
Fuzzy-tester code has historically been inconsistent about how it handles a missing `status` property. By setting a default value, it is assumed that no `status` property means the test is expected to pass.

Since that's how most test frameworks work by default, it seems like the correct base behavior.