### PR TITLE
feat(deps): Remove fs-extra

### DIFF
--- a/output_generators/csv.js
+++ b/output_generators/csv.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var util = require( 'util' );
-var fs = require('fs-extra');
+var fs = require('fs');
 var terminal = require('./terminal');
 var haversine = require( 'haversine' ); // distance measure for angle coords
 

--- a/output_generators/json.js
+++ b/output_generators/json.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var util = require( 'util' );
-var fs = require('fs-extra');
+var fs = require('fs');
 var terminal = require('./terminal');
 var sanitize_filename = require('sanitize-filename');
 
@@ -25,7 +25,7 @@ function replace(key, value) {
 function saveFailTestResult( testCase ) {
   var result = testSuiteHelpers.getMainResult(testCase);
   if( result.result === 'fail' && testCase.status === 'pass' ) {
-    fs.ensureDirSync('./failures');
+    fs.mkdirSync('./failures', { recursive: true });
     var recordFailFile = './failures/' + sanitize_filename(
         util.format('%s_%s.json', testCase.id, testCase.in.text));
     var recordFail = {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "commander": "^4.0.0",
     "deep-diff": "^1.0.0",
     "fj-compose": "^1.1.0",
-    "fs-extra": "^9.0.0",
     "handlebars": "^4.0.5",
     "haversine": "^1.0.0",
     "is-object": "^1.0.1",

--- a/scripts/bulkAcceptanceTestsUpdate.js
+++ b/scripts/bulkAcceptanceTestsUpdate.js
@@ -1,4 +1,4 @@
-var fs = require('fs-extra');
+var fs = require('fs');
 var fileName = process.argv[2];
 var _ = require('lodash');
 var path = require('path');
@@ -63,14 +63,15 @@ function changeTestSuite(file) {
   if (path.extname(file) !== '.json') {
     return;
   }
-  var json = fs.readJSONSync(file);
+  const file_contents = fs.readFileSync(file);
+  var json = JSON.parse(file_contents);
   json.tests = changeTestCases(json.tests);
 
   if (ENDPOINT_MAP.hasOwnProperty(json.endpoint)) {
     json.endpoint = ENDPOINT_MAP[json.endpoint];
   }
 
-  fs.writeJsonSync(file, json);
+  fs.writeSync(file, JSON.stringify(json, null, 2));
 }
 
 function changeTestCases(tests) {

--- a/scripts/resolvePlaceholders.js
+++ b/scripts/resolvePlaceholders.js
@@ -1,4 +1,4 @@
-var fs =  require('fs-extra');
+var fs =  require('fs');
 var path = require('path');
 var request = require('sync-request');
 var _ = require('lodash');
@@ -26,10 +26,12 @@ function changeTestSuite(file) {
   if (path.extname(file) !== '.json') {
     return;
   }
-  var json = fs.readJSONSync(file);
+  const file_contents = fs.readFileSync(file);
+  var json = JSON.parse(file_contents);
+
   json.tests = changeTestCases(json.tests);
 
-  fs.writeJsonSync(file, json);
+  fs.writeSync(file, JSON.stringify(json, null, 2));
 }
 
 function changeTestCases(tests) {


### PR DESCRIPTION
We generally only use the fs-extra package for its `mkdir -p` style convenience wrapper, which can now easily be done with the stock `fs` module.

This removes usage of the fs-extra module and replaces it with native alternatives.

Closes https://github.com/pelias/fuzzy-tester/pull/182