### PR TITLE
feat: Improve distance threshold error message

### DIFF
--- a/lib/scoreCoordinates.js
+++ b/lib/scoreCoordinates.js
@@ -1,5 +1,11 @@
 var haversine = require( 'haversine' ); // distance measure for angle coords
 
+function failMessage(actual, distance, threshold) {
+  const name = actual.properties.label || actual.properties.name;
+
+  return `'${name}' is not close enough: distance is ${distance}m but should be under ${threshold}m`;
+}
+
 /**
  * Calculate the score of an api coordinate result against
  * a single entry of expected coordinates.
@@ -18,9 +24,7 @@ function scoreCoordinates(expected, actual, threshold, weight) {
   return {
     score: pass ? weight : 0,
     max_score: weight,
-    diff: pass ? '' : actual.properties.name +
-      ',' + actual.properties.locality +
-      ' is not close enough, distance=' + dist + ' m'
+    diff: pass ? '' : failMessage(actual, dist, threshold)
   };
 }
 

--- a/test/scoreTest.js
+++ b/test/scoreTest.js
@@ -97,7 +97,7 @@ tape( 'scoreUnexpected basics', function ( test ){
     var result = scoreTest.scoreTest(testCase, features, context);
     t.equal(result.score, 2, 'score is 2');
     t.equal(result.max_score, 3, 'max score is 3');
-    t.deepEquals(result.diff,[ 'test,place is not close enough, distance=7140266 m' ],
+    t.deepEquals(result.diff,[ '\'test\' is not close enough: distance is 7140266m but should be under 1000m' ],
                  'the diff shows the distance from the expected coordinate');
     t.end();
   });
@@ -125,7 +125,8 @@ tape( 'scoreUnexpected basics', function ( test ){
       {
         properties: {
           name: 'test',
-          locality: 'place'
+          locality: 'place',
+          label: 'test, place, country'
         },
         geometry: {
           coordinates: [ 50.0, 50.0]
@@ -136,7 +137,7 @@ tape( 'scoreUnexpected basics', function ( test ){
     var result = scoreTest.scoreTest(testCase, features, context);
     t.equal(result.score, 0, 'score is 0');
     t.equal(result.max_score, 1, 'max score is 1');
-    t.deepEquals(result.diff,[ 'test,place is not close enough, distance=7140266 m' ],
+    t.deepEquals(result.diff,[ '\'test, place, country\' is not close enough: distance is 7140266m but should be under 1000m' ],
                  'the diff shows the distance from the expected coordinate');
     t.end();
   });


### PR DESCRIPTION
This error message has long been a bit awkward, as it didn't use the result label if it existed, and instead expected the `locality` property to be set, which is not always true.

With a little cleanup, the message is now much more friendly and flexible.