### PR TITLE
feat(api keys): Support new `credentials` config property

### DIFF
--- a/lib/apiKey.js
+++ b/lib/apiKey.js
@@ -1,15 +1,28 @@
-var url = require('url'),
-    config = require('pelias-config');
+const url = require('url');
+const logger = require('pelias-logger').get('fuzzy-tester');
+
+const deprecation_message = 'Loading credentials from deprecated `mapzen.api_key` pelias.json property.' +
+  'Credentials should now live in `acceptance-tests.credentials`';
 
 module.exports = function( uri ){
+  const config = require('pelias-config').generate();
+  const host = url.parse( uri ).host;
 
-  var settings = config.generate();
+  const preferred_credentials = config.get('acceptance-tests.credentials');
 
-  if( settings && settings.hasOwnProperty('mapzen') ){
-    var host = url.parse( uri ).host;
-    if( settings.mapzen.hasOwnProperty('api_key') && settings.mapzen.api_key.hasOwnProperty(host) ){
-      return settings.mapzen.api_key[ host ];
-    }
+  const old_credentials = config.get('mapzen.api_key');
+
+  if (preferred_credentials && preferred_credentials[host] !== undefined) {
+    console.log('using new credentials');
+    return preferred_credentials[host] || null;
+  } else {
+    console.log('checking for old credentials');
   }
+
+  if (old_credentials && old_credentials[host]) {
+    logger.warn(deprecation_message);
+    return old_credentials[ host ];
+  }
+
   return null;
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "nodemailer": "^6.3.1",
     "nodemailer-ses-transport": "^1.5.1",
     "pelias-config": "^4.0.0",
+    "pelias-logger": "^1.5.0",
     "request": "^2.55.0",
     "require-dir": "^1.0.0",
     "sanitize-filename": "^1.3.0",

--- a/test/apiKey.js
+++ b/test/apiKey.js
@@ -24,7 +24,7 @@ tape( 'api_key not found in config', function ( test ){
   test.end();
 });
 
-tape( 'stage api_key imported from pelias config', function ( test ){
+tape( 'stage api_key imported from pelias config, old location', function ( test ){
 
   var config = '{ "mapzen": { "api_key": { "pelias.stage.mapzen.com": "my_api_key" } } }';
 
@@ -42,6 +42,38 @@ tape( 'stage api_key imported from pelias config', function ( test ){
 
   // delete temp file
   fs.unlinkSync( '/tmp/pelias_temp2.json' );
+
+  test.end();
+});
+
+tape( 'stage api_key imported from preferred config location first', function ( test ){
+  const custom_config = {
+    'acceptance-tests': {
+      credentials: {
+        'pelias.stage.mapzen.com': 'my_new_api_key'
+      }
+    },
+    mapzen: {
+      api_key: {
+        'pelias.stage.mapzen.com': 'my_old_api_key'
+      }
+    }
+  };
+
+  // write a temporary pelias config
+  fs.writeFileSync( '/tmp/pelias_temp3.json', JSON.stringify(custom_config), 'utf8' );
+
+  // set the PELIAS_CONFIG env var
+  process.env.PELIAS_CONFIG = '/tmp/pelias_temp3.json';
+
+  // staging
+  test.equal( apiKey( 'http://pelias.stage.mapzen.com/foo' ), 'my_new_api_key', 'api key loaded' );
+
+  // unset the PELIAS_CONFIG env var
+  delete process.env.PELIAS_CONFIG;
+
+  // delete temp file
+  fs.unlinkSync( '/tmp/pelias_temp3.json' );
 
   test.end();
 });


### PR DESCRIPTION
This adds support for a `credentials` pelias.json config property, to replace the outdated `mapzen` section where config properties used to be required to live.

The new location is preferred, but API keys can still be loaded from the old location. In that case, a warning will be printed.

Closes https://github.com/pelias/acceptance-tests/issues/465