### PR TITLE
feat: Support configuration of max TCP sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ fuzzy-tester -t dev
 * `-q` Enable quiet mode. Only test failures (not successes) are printed
 * `-t` Select a test 'type' to filter on. This is a free-text value that can be added to each test, to allow running a subset of tests
 * `-r` Set a limit of the number of requests that can be sent per second when running tests. This is useful to avoid overloading a small Pelias server
+* `-m` Set a limit on the maximum number of requests that can be in progress simultaneously (default 1). Higher values can be faster, but can overload a small Pelias server.
 
 ## Test Case Files
 Test-cases are expected to live in `test_cases/`, and are split into test

--- a/lib/processArguments.js
+++ b/lib/processArguments.js
@@ -53,6 +53,11 @@ function setUpCommander() {
     100
   )
   .option(
+    '-m, --max-sockets <int>',
+    'The maxium number of network sockets to open. Higher values can be faster, but can overload small servers.',
+    1
+  )
+  .option(
     '-o, --output <type>',
     outputGeneratorHelp,
     'terminal'
@@ -118,6 +123,7 @@ function getConfig() {
       url: apiUrl,
       name: commander.endpoint
     },
+    maxSockets: commander.maxSockets,
     rate: commander.rate,
     outputGenerator: outputGenerator,
     testType: commander.testType,

--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -27,10 +27,11 @@ function shouldRetryRequest(res) {
 }
 
 function request_urls(config, urls, callback) {
+  const maxSockets = config.maxSockets || 1;
   var total_length = urls.length;
   var responses = {};
-  var httpAgent = new http.Agent({keepAlive: true, maxSockets: 1});
-  var httpsAgent = new https.Agent({keepAlive: true, maxSockets: 1});
+  var httpAgent = new http.Agent({keepAlive: true, maxSockets: maxSockets});
+  var httpsAgent = new https.Agent({keepAlive: true, maxSockets: maxSockets});
   var intervalId;
   const interval = 1000 / config.rate; // the number of miliseconds to delay between requests
   var test_interval = new ExponentialBackoff(interval, 5, interval, 20000);


### PR DESCRIPTION
The fuzzy-tester has historically been designed to be very nice to Pelias servers its testing.

Small Pelias instances can be overwhelmed by too many requests to the point where they take a long time to recover (because Elasticsearch is working through a backlog of requests).

As a result, the fuzzy-tester has always been limited to a _single_ HTTP request in flight at a time. Depending on the rate limit settings (`-r`), new requests might be sent immediately once a previous response is received, but multiple HTTP requests could not occur.

Large Pelias instances, or instances that are far away and have high round trip network delay, would therefore not go through acceptance tests as fast as they potentially could.

This change adds a new parameter, `--max-sockets / -m` which allows raising the number of TCP sockets used by the fuzzy tester. This in effect allows configuring the maximum number of requests in flight at once.

The default is still 1, so the fuzzy-tester will continue to be nice to Pelias servers by default.

But it can now send requests faster to Pelias instances that are known to be able to handle it.