### PR TITLE
Use improvements when calculating pass rate

### DIFF
--- a/output_generators/autocomplete.js
+++ b/output_generators/autocomplete.js
@@ -91,15 +91,17 @@ function prettyPrintSuiteResults( suiteResults, config, testSuites ){
 
   console.log( '\nAggregate test results'.blue );
   console.log( 'Pass: ' + suiteResults.stats.pass.toString().green );
+  console.log( 'Improvements: ' + suiteResults.stats.improvement.toString().green );
   console.log( 'Fail: ' + suiteResults.stats.fail.toString().yellow );
   console.log( 'Placeholders: ' + suiteResults.stats.placeholder.toString().cyan );
 
   var numRegressions = suiteResults.stats.regression;
   var regressionsColor = ( numRegressions > 0 ) ? 'red' : 'yellow';
-  var total = suiteResults.stats.pass +  suiteResults.stats.fail + suiteResults.stats.regression;
+  var total = suiteResults.stats.pass +  suiteResults.stats.fail + suiteResults.stats.regression + suiteResults.stats.improvement;
   var pass = total - numRegressions;
 
   console.log( 'Regressions: ' + numRegressions.toString()[ regressionsColor ] );
+  console.log( 'Total tests: ' + total );
   console.log( 'Took %sms', suiteResults.stats.timeTaken );
   console.log( 'Test success rate %s%%', percentageForDisplay(total, pass));
   console.log( '' );

--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -128,10 +128,11 @@ function prettyPrintSuiteResults( suiteResults, config, testSuites ){
   console.log( 'Placeholders: ' + suiteResults.stats.placeholder.toString().cyan );
 
   var numRegressions = suiteResults.stats.regression;
-  var total = suiteResults.stats.pass +  suiteResults.stats.fail + suiteResults.stats.regression;
+  var total = suiteResults.stats.pass +  suiteResults.stats.fail + suiteResults.stats.regression + suiteResults.stats.improvement;
   var pass = total - numRegressions;
 
   console.log( 'Regressions: ' + numRegressions.toString().red);
+  console.log( 'Total tests: ' + total );
   console.log( 'Took %sms', suiteResults.stats.timeTaken );
   console.log( 'Test success rate %s%%', percentageForDisplay(total,pass));
 


### PR DESCRIPTION
It turns out we were not using the number of `improvements` (tests expected to fail that actually passed) when calculating the total number of tests, and therefore the percentage pass rate of the complete test suite.

This has the effect of under-reporting pass rate in situations where there are improvements.

Also, the autocomplete output generator was not printing improvements, so it was looking like tests could "disappear" from results across different runs.