### PR TITLE
add Header mode for credentials + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,21 @@ override the default aliases and define your own in `pelias-config`:
 
 
 ### Credentials
-You can specify api keys for different hosts in the pelias-config. There is an optional dict of credentials in
-`acceptance-tests.credentials`. The keys are bare hostnames (with no path or protocol). The values can either be a
-string, which will be added to the urls as `&api_key=${value}` which is the default pelias api key schema, but it can
-also be a dict that specifies `method=Header` (which will send credentials in the http authorization header) or 
-`method=GET` (which supports an optional key "keyName", which if specified means it will be added to urls like `&${keyName}=${value}`)
+
+You can specify api keys for different hosts via `pelias.json` in the `acceptance-tests.credentials`
+section.
+
+The keys are bare hostnames (with no path or protocol). The values can either be a string, or an
+object.
+
+If using a string, the string will be used as an API key and appended to the query URL with
+`&api_key=${value}`.  or an object.
+
+If using an object, the `method` property can be specified as either `GET` (the default`) or
+`Header`. Selecting `Header` will send the API key in the `authorization:` HTTP header.
+
+The optional `keyName` property can be specified with `GET` if an authorization URL other than
+`api_key` is required.
 
 ```javascript
 {
@@ -194,6 +204,11 @@ also be a dict that specifies `method=Header` (which will send credentials in th
       "pelias-staging.myhost.com": 'secret_key_12342354',
       "pelias-prod.myhost.com": {
         "method": "Header",
+        "value": "prj_sk_XXXXXXXXX"
+      },
+      "pelias-testing.myhost.com": {
+        "method": "GET",
+		"keyName": "my_auth_parameter",
         "value": "prj_sk_XXXXXXXXX"
       }
     }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,36 @@ override the default aliases and define your own in `pelias-config`:
 {
   "acceptance-tests": {
     "endpoints": {
-      "alias": "http://my.pelias.instance"
+      "prod": "http://pelias-prod.myhost.com/protectedpath/",
+      "staging": "http://pelias-staging.myhost.com",
+      "localhost": "http://localhost:3100"
+    }
+  }
+}
+```
+
+
+### Credentials
+You can specify api keys for different hosts in the pelias-config. There is an optional dict of credentials in
+`acceptance-tests.credentials`. The keys are bare hostnames (with no path or protocol). The values can either be a
+string, which will be added to the urls as `&api_key=${value}` which is the default pelias api key schema, but it can
+also be a dict that specifies `method=Header` (which will send credentials in the http authorization header) or 
+`method=GET` (which supports an optional key "keyName", which if specified means it will be added to urls like `&${keyName}=${value}`)
+
+```javascript
+{
+  "acceptance-tests": {
+    "endpoints": {
+      "prod": "http://pelias-prod.myhost.com/protectedpath/",
+      "staging": "http://pelias-staging.myhost.com",
+      "localhost": "http://localhost:3100"
+    },
+    "credentials": {
+      "pelias-staging.myhost.com": 'secret_key_12342354',
+      "pelias-prod.myhost.com": {
+        "method": "Header",
+        "value": "prj_sk_XXXXXXXXX"
+      }
     }
   }
 }

--- a/lib/apiKey.js
+++ b/lib/apiKey.js
@@ -1,8 +1,23 @@
 const url = require('url');
+const _ = require('lodash');
 const logger = require('pelias-logger').get('fuzzy-tester');
 
 const deprecation_message = 'Loading credentials from deprecated `mapzen.api_key` pelias.json property.' +
   'Credentials should now live in `acceptance-tests.credentials`';
+
+function processCredentials(credentials) {
+  if (_.isObject(credentials)) {
+    return credentials;
+  } else if (_.isString(credentials)) {
+    return {
+      method: 'GET',
+      keyName: 'api_key',
+      value: credentials
+    };
+  } else {
+    throw new Error('credentials entry must be a string or an object', credentials);
+  }
+}
 
 module.exports = function( uri ){
   const config = require('pelias-config').generate();
@@ -13,12 +28,12 @@ module.exports = function( uri ){
   const old_credentials = config.get('mapzen.api_key');
 
   if (preferred_credentials && preferred_credentials[host] !== undefined) {
-    return preferred_credentials[host] || null;
+    return processCredentials(preferred_credentials[host]);
   }
 
   if (old_credentials && old_credentials[host]) {
     logger.warn(deprecation_message);
-    return old_credentials[ host ];
+    return processCredentials(old_credentials[host]);
   }
 
   return null;

--- a/lib/gather_test_urls.js
+++ b/lib/gather_test_urls.js
@@ -1,4 +1,3 @@
-var apiKey = require( '../lib/apiKey' );
 var url = require ('url');
 var _ = require('lodash');
 
@@ -48,13 +47,9 @@ function gatherAutocompleteURLs(testCase, baseUrlObj) {
 function gatherTestSuiteURLs( config, testSuite ){
   var apiUrl = config.endpoint.url;
 
-  var key = apiKey( apiUrl );
   var baseUrlObj = url.parse(apiUrl);
 
   return _.flatten(testSuite.tests.map(function(testCase) {
-    if( key ){
-      testCase.in.api_key = key;
-    }
     testCase.autocompleteURLs = [];
 
     var testCaseURLs = [gatherTestCaseURL(testCase, testSuite, baseUrlObj)];

--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var https = require('https');
 var request = require('request');
+var apiKey = require( '../lib/apiKey' );
 
 var ExponentialBackoff = require( '../lib/ExponentialBackoff');
 
@@ -37,6 +38,9 @@ function request_urls(config, urls, callback) {
   var test_interval = new ExponentialBackoff(interval, 5, interval, 20000);
   var delay = test_interval.getBackoff();
 
+  var apiUrl = config.endpoint.url;
+  var key = apiKey( apiUrl );
+
   var getOneUrl = function (){
     // check if all responses have been recieved and call the next step in
     // processing via the `callback` function
@@ -63,6 +67,14 @@ function request_urls(config, urls, callback) {
       agent: agent,
       gzip: true
     };
+
+    if (key && key.method === 'Header') {
+      requestOpts.headers.authorization = `${key.value}`;
+    }
+
+    if (key && key.method === 'GET') {
+      requestOpts.url = url + `&${key.keyName}=${key.value}`;
+    }
 
     request( requestOpts, function ( err, res ){
       if( err ){


### PR DESCRIPTION
We have a custom server in front of our pelias with some application
level hacks. It uses http header auth. I would like to be able to use
pelias fuzzy tester to see the differences, especially in autocomplete
testing, between our raw backend pelias, and this hacked up proxied
pelias. This change allows for that.
