### PR TITLE
Normalize unexpected properties

### DIFF
--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -143,7 +143,7 @@ function evalTest( testCase, apiResponse, context ){
   }
 
   // normalize expected and actual properties in preparation for scoreTest
-  testCase = normalizeExpected(testCase, context.propertyNormalizers);
+  testCase = normalizeTestCase(testCase, context.propertyNormalizers);
   apiResponse = normalizeActual(apiResponse, context.propertyNormalizers);
 
   var score = scoreTest.scoreTest(testCase, apiResponse, context);
@@ -158,25 +158,40 @@ function evalTest( testCase, apiResponse, context ){
   };
 }
 
-function normalizeExpected(testCase, fieldNormalizers) {
-  if (!hasAnArrayOfExpectedProperties(testCase)) {
-    return testCase;
+function normalizeTestCase(testCase, fieldNormalizers) {
+  if (hasAnArrayOfExpectedProperties(testCase)) {
+    // normalize all expected properties that have normalizers
+    testCase.expected.properties = testCase.expected.properties.map(function(obj) {
+      Object.keys(obj).
+        // find all properties with normalizers
+        filter(function(key) {
+          return fieldNormalizers[key];
+        }).
+        // apply normalizers
+        forEach(function(key) {
+          obj[key] = fieldNormalizers[key](obj[key]);
+        });
+
+      return obj;
+    });
   }
 
-  // normalize all expected properties that have normalizers
-  testCase.expected.properties = testCase.expected.properties.map(function(obj) {
-    Object.keys(obj).
-      // find all properties with normalizers
-      filter(function(key) {
-        return fieldNormalizers[key];
-      }).
-      // apply normalizers
-      forEach(function(key) {
-        obj[key] = fieldNormalizers[key](obj[key]);
-      });
+  if (hasAnArrayOfUnexpectedProperties(testCase)) {
+    // normalize all unexpected properties that have normalizers
+    testCase.unexpected.properties = testCase.unexpected.properties.map(function(obj) {
+      Object.keys(obj).
+        // find all properties with normalizers
+        filter(function(key) {
+          return fieldNormalizers[key];
+        }).
+        // apply normalizers
+        forEach(function(key) {
+          obj[key] = fieldNormalizers[key](obj[key]);
+        });
 
-    return obj;
-  });
+      return obj;
+    });
+  }
 
   return testCase;
 }
@@ -201,6 +216,12 @@ function hasAnArrayOfExpectedProperties(testCase) {
   return testCase.hasOwnProperty('expected') &&
           testCase.expected.hasOwnProperty('properties') &&
           _.isArray(testCase.expected.properties);
+}
+
+function hasAnArrayOfUnexpectedProperties(testCase) {
+  return testCase.hasOwnProperty('unexpected') &&
+          testCase.unexpected.hasOwnProperty('properties') &&
+          _.isArray(testCase.unexpected.properties);
 }
 
 module.exports = evalTest;

--- a/lib/eval_test.js
+++ b/lib/eval_test.js
@@ -158,58 +158,39 @@ function evalTest( testCase, apiResponse, context ){
   };
 }
 
+function normalizeProperties(properties, fieldNormalizers) {
+  Object.keys(properties).
+    // find all properties with normalizers
+    filter(key => fieldNormalizers[key]).
+    // apply normalizers
+    forEach(key => {
+      properties[key] = fieldNormalizers[key](properties[key]);
+    });
+
+  return properties;
+}
+
 function normalizeTestCase(testCase, fieldNormalizers) {
   if (hasAnArrayOfExpectedProperties(testCase)) {
     // normalize all expected properties that have normalizers
-    testCase.expected.properties = testCase.expected.properties.map(function(obj) {
-      Object.keys(obj).
-        // find all properties with normalizers
-        filter(function(key) {
-          return fieldNormalizers[key];
-        }).
-        // apply normalizers
-        forEach(function(key) {
-          obj[key] = fieldNormalizers[key](obj[key]);
-        });
-
-      return obj;
-    });
+    testCase.expected.properties = testCase.expected.properties.map(properties => normalizeProperties(properties, fieldNormalizers));
   }
 
   if (hasAnArrayOfUnexpectedProperties(testCase)) {
     // normalize all unexpected properties that have normalizers
-    testCase.unexpected.properties = testCase.unexpected.properties.map(function(obj) {
-      Object.keys(obj).
-        // find all properties with normalizers
-        filter(function(key) {
-          return fieldNormalizers[key];
-        }).
-        // apply normalizers
-        forEach(function(key) {
-          obj[key] = fieldNormalizers[key](obj[key]);
-        });
-
-      return obj;
-    });
+    testCase.unexpected.properties = testCase.unexpected.properties.map(properties => normalizeProperties(properties, fieldNormalizers));
   }
 
   return testCase;
 }
 
 function normalizeActual(apiResponse, fieldNormalizers) {
-  return apiResponse.map(function(obj) {
-    Object.keys(obj.properties).
-      // find all properties with normalizers
-      filter( function(key) {
-        return fieldNormalizers[key];
-      }).
-      /// apply normalizers
-      forEach( function(key) {
-        obj.properties[key] = fieldNormalizers[key](obj.properties[key]);
-      });
-
-    return obj;
+  apiResponse.forEach((response) => {
+    if (response.properties) {
+      response.properties = normalizeProperties(response.properties, fieldNormalizers);
+    }
   });
+  return apiResponse;
 }
 
 function hasAnArrayOfExpectedProperties(testCase) {

--- a/test/eval_test.js
+++ b/test/eval_test.js
@@ -274,6 +274,26 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
       expected: 'pass'
     },
     {
+      description: 'normalizers should be applied to unexpected properties',
+      priorityThresh: 2,
+      apiResults: [{
+        properties: {
+          a: 'UNEXPECTED'
+        }
+      }],
+      testCase: {
+        unexpected: {
+          properties: [{
+            a: 'Unexpected'
+          }]
+        },
+        normalizers: {
+          a: ['toLowerCase']
+        }
+      },
+      expected: 'fail'
+    },
+    {
       description: 'properties without normalizers should match exactly',
       priorityThresh: 1,
       apiResults: [{


### PR DESCRIPTION
Without normalizers being applied, many unexpected property checks are likely passing, when they really should fail.

For example, an unexpected property check for 'FOO', would not alert to the existice of 'Foo', even if there was a `toLowerCase` normalizer set for that property.

I've also included some nice refactoring in this PR. There is logic that can be shared across the now 3 places we do normalization (test expected properties, test unexpected properties, and the actual response properties)