### PR TITLE
fix inifinte loop with invalid hostname

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -76,10 +76,15 @@ function request_urls(config, urls, callback) {
       requestOpts.url = url + `&${key.keyName}=${key.value}`;
     }
 
-    request( requestOpts, function ( err, res ){
-      if( err ){
-        console.error( err );
-        urls.push(url);
+    request(requestOpts, function (err, res) {
+      if (err) {
+        console.error(err);
+        //Check if hostname is valid. Abort execution if not
+        if (err.code === 'ENOTFOUND') {
+          throw new Error('Invalid hostname, exiting');
+        }
+        else {
+          urls.push(url);
       }
       else if( shouldRetryRequest(res) ){
         urls.push(url);

--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -81,7 +81,7 @@ function request_urls(config, urls, callback) {
         console.error( err );
         //Check if hostname is valid. Abort execution if not
         if( err.code === 'ENOTFOUND' ) {
-          throw new Error( 'Invalid hostname, exiting' );
+          throw new Error( 'Invalid hostname: "'+ err.hostname + '". Stopping execution.' );
         }
         urls.push(url);
       }

--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -76,15 +76,14 @@ function request_urls(config, urls, callback) {
       requestOpts.url = url + `&${key.keyName}=${key.value}`;
     }
 
-    request(requestOpts, function (err, res) {
-      if (err) {
-        console.error(err);
+    request( requestOpts, function ( err, res ){
+      if( err ){
+        console.error( err );
         //Check if hostname is valid. Abort execution if not
-        if (err.code === 'ENOTFOUND') {
-          throw new Error('Invalid hostname, exiting');
+        if( err.code === 'ENOTFOUND' ) {
+          throw new Error( 'Invalid hostname, exiting' );
         }
-        else {
-          urls.push(url);
+        urls.push(url);
       }
       else if( shouldRetryRequest(res) ){
         urls.push(url);


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
- Fixes #211 

---
#### Here's what actually got changed :clap:
Add another check for the error type. If it is "ENOTFOUND" it now will throw an error and abort the execution.
https://github.com/arnesetzer/pelias-fuzzy-tester/blob/fixInvalidHost/lib/request_urls.js#L83

---
#### Here's how others can test the changes :eyes:
Try a invalid hostname. This should now throw a new error at the first occurance and exit instead of trying to reconnect to this host till ctrl+c.
