### PR TITLE
Add support to `size` that check the number of results

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,7 @@
   "node": true,
   "curly": true,
   "eqeqeq": true,
-  "esversion": 6,
+  "esversion": 11,
   "freeze": true,
   "immed": true,
   "indent": 2,

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ properties:
 
    Coordinate based tests also help to track invalid location data in the search database.
 
+   `size` property that will check the number of results, you can set a number or a String with a comparison sign
+   (`<`, `<=`, `>`, `>=` or `==`). If the sign is not recognized, the test will fail. Usage example: `> 5` will ensure
+   a number or result greater than 5.
+
  + `unexpected` is analogous to `expected`, except that you *cannot* specify a `priorityThresh` and the `properties`
   array does *not* support strings.
  + `weights` (optional) test case specific weighting for scores of the individual expectations. See the

--- a/lib/sanitiseTestCase.js
+++ b/lib/sanitiseTestCase.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const _ = require('lodash');
 /**
  * Given the properties of a test case,
  * construct the actual expected object.
@@ -57,6 +57,10 @@ function normalizeCoordinates(coordinates) {
   return coordinates;
 }
 
+function normalizeSize(size) {
+  return _.isNumber(size) ? size.toString() : size;
+}
+
 function sanitiseTestCase(testCase, locations) {
   locations = locations || {};
 
@@ -79,6 +83,9 @@ function sanitiseTestCase(testCase, locations) {
     var unmatched_placeholders = findPlaceholders(testCase.expected.properties);
     if (unmatched_placeholders.length > 0) {
       return 'Placeholder: no matches for ' + unmatched_placeholders.join(', ') + ' in `locations.json`.';
+    }
+    if (!_.isNil(testCase.expected.size)) {
+      testCase.expected.size = normalizeSize(testCase.expected.size);
     }
   }
 

--- a/lib/scoreTest.js
+++ b/lib/scoreTest.js
@@ -2,7 +2,7 @@ var helpers = require( '../lib/scoreHelpers' );
 var equalProperties = require( '../lib/equal_properties' );
 var scoreCoordinates = require( '../lib/scoreCoordinates' );
 var scoreProperties = require( '../lib/scoreProperties' );
-
+const _ = require('lodash');
 /**
  * Calculate the score component for a response feature object's position in the returned
  * response features. If it is later in the featuress than the threshold, no points.
@@ -127,6 +127,28 @@ function scoreOneCoordinateExpectation(expected_coords, responseFeatures, contex
   }).sort(sortScores)[0];
 }
 
+function evaluateSymbol(size, length) {
+  const exec = /^(?<symbol>[<>=]+)?\s*(?<number>[0-9]+)$/.exec(size.trim());
+  const symbol = exec?.groups?.symbol || '==';
+  const number = _.parseInt(exec?.groups?.number);
+  switch(symbol) {
+    case '<=': return length <= number;
+    case '<': return length < number;
+    case '>=': return length >= number;
+    case '>': return length > number;
+    case '==': return length === number;
+    default: return false;
+  }
+}
+
+function scoreSize(size, responseFeatures) {
+  const scored = evaluateSymbol(size, responseFeatures.length);
+  if (!scored) {
+    return {score: 0, max_score: 1, diff: [`size is ${size} but found ${responseFeatures.length}`]};
+  }
+  return {score: 1, max_score: 1, diff: []};
+}
+
 /**
  * Score an entire test by combining the score for each expectation,
  * and the score for any unexpected properties.
@@ -147,6 +169,10 @@ function scoreTest(testCase, responseFeatures, context) {
       scores = scores.concat(testCase.expected.coordinates.map(function(expected_coords) {
         return scoreOneCoordinateExpectation(expected_coords, responseFeatures, context);
       }));
+    }
+
+    if (_.isString(testCase.expected.size)) {
+      scores = scores.concat(scoreSize(testCase.expected.size, responseFeatures));
     }
   }
 

--- a/test/eval_test.js
+++ b/test/eval_test.js
@@ -344,6 +344,22 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
       expected: 'fail'
     },
     {
+      description: 'size supports comparison signs, two results - pass',
+      priorityThresh: 1,
+      apiResults: [{
+        properties: {}
+      },{
+        properties: {}
+      }],
+      testCase: {
+        expected: {
+          properties: {},
+          size: '>=2'
+        }
+      },
+      expected: 'pass'
+    },
+    {
       description: 'size supports comparison signs - pass',
       priorityThresh: 1,
       apiResults: [{

--- a/test/eval_test.js
+++ b/test/eval_test.js
@@ -314,6 +314,76 @@ tape( 'evalTest() evaluates all edge cases correctly', function ( test ){
         }
       },
       expected: 'pass'
+    },
+    {
+      description: 'size should match exactly - pass',
+      priorityThresh: 1,
+      apiResults: [{
+        properties: {}
+      }],
+      testCase: {
+        expected: {
+          properties: {},
+          size: 1
+        }
+      },
+      expected: 'pass'
+    },
+    {
+      description: 'size should match exactly - fail',
+      priorityThresh: 1,
+      apiResults: [{
+        properties: {}
+      }],
+      testCase: {
+        expected: {
+          properties: {},
+          size: 0
+        }
+      },
+      expected: 'fail'
+    },
+    {
+      description: 'size supports comparison signs - pass',
+      priorityThresh: 1,
+      apiResults: [{
+        properties: {}
+      }],
+      testCase: {
+        expected: {
+          properties: {},
+          size: '>=1'
+        }
+      },
+      expected: 'pass'
+    },
+    {
+      description: 'size supports comparison signs - pass',
+      priorityThresh: 1,
+      apiResults: [{
+        properties: {}
+      }],
+      testCase: {
+        expected: {
+          properties: {},
+          size: '< 1'
+        }
+      },
+      expected: 'fail'
+    },
+    {
+      description: 'size wrong input - fail',
+      priorityThresh: 1,
+      apiResults: [{
+        properties: {}
+      }],
+      testCase: {
+        expected: {
+          properties: {},
+          size: 's 1'
+        }
+      },
+      expected: 'fail'
     }
   ];
 


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

I was looking for a way to ensure the number of results on a search/autocomplete related to #90. I added the possibility to use comparison symbols too. 

---
#### Here's what actually got changed :clap:

Now your test cases can include the property `size` which can be a number or a String with a comparison symbol. By default we will check if the number of results is equal to that number or not.

---
#### Here's how others can test the changes :eyes:
Example of test case using size
```json
{
  "id": 20,
  "status": "pass",
  "user": "joxit",
  "in": {
    "layers": "street",
    "text": "Avenue Aristide Briand, Bagneux"
  },
  "expected": {
    "size": 1,
    "properties": [
      {
        "name": "Avenue Aristide Briand",
        "localadmin": "Bagneux",
        "layer": "street",
        "country_code": "FR"
      }
    ]
  }
}
```

closes #90 