### PR TITLE
docs(readme): change remove to autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ properties:
     Each test case can include a specific threshold value. This makes sense because location of a neigborhood is not as accurately defined as location of,
     say, a building. Default threshold is 500 meters.
  + `tests` is an array of test cases that make up the suite.
- + `endpoint` the API endpoint (`search`, `reverse`, `suggest`) to target. Defaults to `search`.
+ + `endpoint` the API endpoint (`search`, `reverse`, `autocomplete`) to target. Defaults to `search`.
  + `weights` (optional) test suite wide weighting for scores of the individual expectations. See the
    weights section below
 


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
Since the `suggest` endpoint was removed in 2015 ( https://github.com/pelias/api/pull/165/files ) it does not make sense to keep this legacy in the README and confuse people. Since suggest is already mapped to autocomplete
https://github.com/pelias/fuzzy-tester/blob/7d67a520c56576cd4363bd368e0afef7f808736d/scripts/bulkAcceptanceTestsUpdate.js#L21-L23
legacy installations will not be affected.

---
#### Here's what actually got changed :clap:
- README.md
---
