### PR TITLE
Replace deprecated url.parse() with WHATWG URL API

### DIFF
--- a/lib/apiKey.js
+++ b/lib/apiKey.js
@@ -1,4 +1,3 @@
-const url = require('url');
 const _ = require('lodash');
 const logger = require('pelias-logger').get('fuzzy-tester');
 
@@ -21,7 +20,7 @@ function processCredentials(credentials) {
 
 module.exports = function( uri ){
   const config = require('pelias-config').generate();
-  const host = url.parse( uri ).host;
+  const host = new URL( uri ).host;
 
   const preferred_credentials = config.get('acceptance-tests.credentials');
 

--- a/lib/gather_test_urls.js
+++ b/lib/gather_test_urls.js
@@ -1,17 +1,16 @@
-var url = require ('url');
 var _ = require('lodash');
 
 function gatherTestCaseURL(testCase, testSuite, baseUrlObj) {
   var endpoint = testCase.endpoint || testSuite.endpoint || 'search';
 
-  var urlObj = {
-    pathname: baseUrlObj.pathname + '/' + endpoint,
-    host: baseUrlObj.host,
-    protocol: baseUrlObj.protocol,
-    query: testCase.in
-  };
+  var urlObj = new URL(baseUrlObj);
+  urlObj.pathname = urlObj.pathname + '/' + endpoint;
 
-  testCase.full_url = url.format(urlObj);
+  for (var key of Object.keys(testCase.in)) {
+    urlObj.searchParams.set(key, testCase.in[key]);
+  }
+
+  testCase.full_url = urlObj.toString();
   return testCase.full_url;
 }
 
@@ -29,14 +28,14 @@ function gatherAutocompleteURLs(testCase, baseUrlObj) {
     var query = _.clone(baseQuery);
     query.text = baseQuery.text.substring(0, i);
 
-    var urlObj = {
-      pathname: baseUrlObj.pathname + '/autocomplete',
-      host: baseUrlObj.host,
-      protocol: baseUrlObj.protocol,
-      query: query
-    };
+    var urlObj = new URL(baseUrlObj);
+    urlObj.pathname = urlObj.pathname + '/autocomplete';
 
-    var autocompleteURL = url.format(urlObj);
+    for (var key of Object.keys(query)) {
+      urlObj.searchParams.set(key, query[key]);
+    }
+
+    var autocompleteURL = urlObj.toString();
     autocompleteURLs.push(autocompleteURL);
   }
 
@@ -47,7 +46,7 @@ function gatherAutocompleteURLs(testCase, baseUrlObj) {
 function gatherTestSuiteURLs( config, testSuite ){
   var apiUrl = config.endpoint.url;
 
-  var baseUrlObj = url.parse(apiUrl);
+  var baseUrlObj = new URL(apiUrl);
 
   return _.flatten(testSuite.tests.map(function(testCase) {
     testCase.autocompleteURLs = [];


### PR DESCRIPTION
## Summary
Fixes DEP0169 deprecation warning by replacing `url.parse()` with the WHATWG URL API.

```bash
(node:86271) [DEP0169] DeprecationWarning: url.parse() behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for url.parse() vulnerabilities.
(Use node --trace-deprecation ... to show where the warning was created)
```

## Changes
- Migrated from legacy `url.parse()` to `new URL()`
- Uses standardized WHATWG URL API throughout