### PR TITLE
fix(ci): bump Node to 22.x for semantic-release, require >=20 in engines

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "trim": "^1.0.0"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=20.0.0"
   },
   "release": {
     "success": []


### PR DESCRIPTION
@orangejulius  Should fix the GHA publish issue 