### PR TITLE
fix: use actual request URL in terminal output instead of hardcoded /v1/

### DIFF
--- a/output_generators/terminal.js
+++ b/output_generators/terminal.js
@@ -14,7 +14,7 @@ var percentageForDisplay = require('../lib/percentageForDisplay');
 var testSuiteHelpers = require('../lib/test_suite_helpers');
 
 function inputToUrl(testCase) {
-  const path = `/v1/${testCase.endpoint}`;
+  const path = new URL(testCase.full_url).pathname;
 
   const paramStrings = [];
 


### PR DESCRIPTION
The `inputToUrl` display function hardcoded `/v1/` as the path prefix, which was wrong for other endpoints. Now uses `testCase.full_url` which is already set by `gather_test_urls.js`.
