### PR TITLE
Request performance: track finished requests to reduce Object.keys calls

### DIFF
--- a/lib/request_urls.js
+++ b/lib/request_urls.js
@@ -72,6 +72,7 @@ function request_urls(config, urls, callback) {
   const maxSockets = config.maxSockets || 1;
   var total_length = urls.length;
   var responses = {};
+  var done_count = 0;
   var httpAgent = new http.Agent({keepAlive: true, maxSockets: maxSockets});
   var httpsAgent = new https.Agent({keepAlive: true, maxSockets: maxSockets});
   var intervalId;
@@ -85,7 +86,7 @@ function request_urls(config, urls, callback) {
   var getOneUrl = function (){
     // check if all responses have been recieved and call the next step in
     // processing via the `callback` function
-    if( Object.keys(responses).length === total_length ){
+    if( done_count === total_length ){
       clearInterval(intervalId);
       return callback( responses );
     }
@@ -127,17 +128,18 @@ function request_urls(config, urls, callback) {
       else if( shouldRetryRequest(res) ){
         urls.push(url);
         retries++;
-        printProgress(Object.keys(responses).length, total_length);
+        printProgress(done_count, total_length);
         test_interval.increaseBackoff();
       }
       else {
         responses[url] = res;
+        done_count++;
         test_interval.decreaseBackoff();
 
-        printProgress(Object.keys(responses).length, total_length);
+        printProgress(done_count, total_length);
       }
 
-      if( Object.keys(responses).length === total_length ){
+      if( done_count === total_length ){
         clearInterval(intervalId);
         callback( responses );
       } else {


### PR DESCRIPTION
This reduces an O(N) operation called many times in tight callback loops to an O(1). Should help make tests faster both individually and especially as test suite sizes grow into the thousands.